### PR TITLE
Package OpenXR OBS Mirror v0.3.0 beta release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bin/
 **/x64/
 **/obj/
 **/__pycache__/
+artifacts/
 *.pyc
 *.vcxproj.user
 *.csproj.user

--- a/ControlCenter/MainWindow.xaml
+++ b/ControlCenter/MainWindow.xaml
@@ -259,6 +259,29 @@
                                             <TextBlock Text="Adds room above and below the headset crop." Style="{StaticResource MutedTextStyle}" FontSize="12" />
                                         </StackPanel>
 
+                                        <Border CornerRadius="14" Padding="16" Background="#80333A4A">
+                                            <StackPanel Spacing="10">
+                                                <Grid>
+                                                    <StackPanel Margin="0,0,88,0">
+                                                        <TextBlock Text="Match fullscreen effects at the FOV boundary" FontWeight="SemiBold" />
+                                                        <TextBlock x:Name="BoundaryCompensationSummaryText"
+                                                                   Text="Off — the overscan perimeter is copied exactly as rendered."
+                                                                   Style="{StaticResource MutedTextStyle}" FontSize="12" TextWrapping="Wrap" />
+                                                    </StackPanel>
+                                                    <ToggleSwitch x:Name="BoundaryCompensationToggle" HorizontalAlignment="Right" VerticalAlignment="Top"
+                                                                  Toggled="OverscanToggle_Toggled" />
+                                                </Grid>
+                                                <Grid>
+                                                    <TextBlock Text="Match strength" Style="{StaticResource MutedTextStyle}" />
+                                                    <TextBlock x:Name="BoundaryCompensationStrengthText" Text="100%" HorizontalAlignment="Right"
+                                                               Foreground="{StaticResource BrandBrush}" FontWeight="SemiBold" />
+                                                </Grid>
+                                                <Slider x:Name="BoundaryCompensationStrengthSlider" ValueChanged="OverscanSlider_ValueChanged" />
+                                                <TextBlock Text="Recording only. Useful when a projection-baked blur, tint, vignette, or fade ends at the headset's native FOV."
+                                                           Style="{StaticResource MutedTextStyle}" FontSize="12" TextWrapping="Wrap" />
+                                            </StackPanel>
+                                        </Border>
+
                                         <StackPanel Spacing="9">
                                             <TextBlock Text="PRESETS" Style="{StaticResource EyebrowStyle}" />
                                             <StackPanel Orientation="Horizontal" Spacing="9">

--- a/ControlCenter/MainWindow.xaml.cs
+++ b/ControlCenter/MainWindow.xaml.cs
@@ -27,6 +27,7 @@ public sealed partial class MainWindow : Window
 
         ConfigureOverscanSlider(HorizontalSlider, 115);
         ConfigureOverscanSlider(VerticalSlider, 108);
+        ConfigureSlider(BoundaryCompensationStrengthSlider, 0, 100, 1, 100);
         ConfigureSlider(SmoothingSlider, 0, 100, 1, 35);
         ConfigureSlider(SmoothingCropSlider, 0, 25, 0.5, 8);
         ExtendsContentIntoTitleBar = true;
@@ -177,6 +178,8 @@ public sealed partial class MainWindow : Window
         OverscanToggle.IsOn = snapshot.OverscanEnabled;
         HorizontalSlider.Value = snapshot.HorizontalPercent;
         VerticalSlider.Value = snapshot.VerticalPercent;
+        BoundaryCompensationToggle.IsOn = snapshot.OverscanBoundaryCompensation;
+        BoundaryCompensationStrengthSlider.Value = snapshot.OverscanBoundaryCompensationStrength;
         _loadingControls = false;
         UpdateOverscanPreview();
 
@@ -293,6 +296,12 @@ public sealed partial class MainWindow : Window
         PixelCostText.Text = $"+{pixelCost * 100:0.0}%";
         ScaleSummaryText.Text = $"{horizontal / 100.0:0.00}× horizontal  •  {vertical / 100.0:0.00}× vertical";
         ExpectedTextureText.Text = $"{horizontal / 100.0:0.00}×  ×  {vertical / 100.0:0.00}×";
+        var boundaryStrength = (int)Math.Round(BoundaryCompensationStrengthSlider.Value);
+        BoundaryCompensationStrengthText.Text = $"{boundaryStrength}%";
+        BoundaryCompensationStrengthSlider.IsEnabled = BoundaryCompensationToggle.IsOn;
+        BoundaryCompensationSummaryText.Text = BoundaryCompensationToggle.IsOn
+            ? "Matches projection-baked fullscreen effects across the extra recording perimeter."
+            : "Off — the overscan perimeter is copied exactly as rendered.";
     }
 
     private void SmoothingControl_Changed(object sender, RoutedEventArgs e)
@@ -440,7 +449,13 @@ public sealed partial class MainWindow : Window
                 OverscanToggle.IsOn,
                 (int)Math.Round(HorizontalSlider.Value),
                 (int)Math.Round(VerticalSlider.Value));
-            ShowMessage("Overscan settings saved", "Restart the VR application for the new FOV and render size to take effect.", InfoBarSeverity.Success);
+            _service.ApplyOverscanBoundaryCompensation(
+                BoundaryCompensationToggle.IsOn,
+                (int)Math.Round(BoundaryCompensationStrengthSlider.Value));
+            ShowMessage(
+                "Overscan settings saved",
+                "FOV and render-size changes apply after restarting the VR application. Guard-band matching then updates live.",
+                InfoBarSeverity.Success);
             await RefreshSnapshotAsync();
         }
         catch (Exception ex)

--- a/ControlCenter/Models/SystemSnapshot.cs
+++ b/ControlCenter/Models/SystemSnapshot.cs
@@ -23,6 +23,8 @@ public sealed record SystemSnapshot(
     bool OverscanEnabled,
     int HorizontalPercent,
     int VerticalPercent,
+    bool OverscanBoundaryCompensation,
+    int OverscanBoundaryCompensationStrength,
     bool CameraSmoothingManaged,
     int CameraSmoothing,
     double SmoothingCrop,

--- a/ControlCenter/OBSMirror.ControlCenter.csproj
+++ b/ControlCenter/OBSMirror.ControlCenter.csproj
@@ -16,6 +16,10 @@
     <RootNamespace>OBSMirror.ControlCenter</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\OBSMirror.ControlCenter.ico</ApplicationIcon>
+    <Version>0.3.0-beta.1</Version>
+    <AssemblyVersion>0.3.0.1</AssemblyVersion>
+    <FileVersion>0.3.0.1</FileVersion>
+    <InformationalVersion>0.3.0-beta.1</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ControlCenter/Services/OBSMirrorService.cs
+++ b/ControlCenter/Services/OBSMirrorService.cs
@@ -39,6 +39,7 @@ public sealed class OBSMirrorService
     public SystemSnapshot GetSnapshot()
     {
         var (enabled, horizontal, vertical) = ReadOverscan();
+        var (boundaryCompensation, boundaryCompensationStrength) = ReadOverscanBoundaryCompensation();
         var (smoothingManaged, cameraSmoothing, smoothingCrop) = ReadCameraSmoothing();
         var mirrorQuadLayers = ReadMirrorQuadLayers();
         var runtime = ResolveRuntimeSelection();
@@ -77,6 +78,8 @@ public sealed class OBSMirrorService
             OverscanEnabled: enabled,
             HorizontalPercent: horizontal,
             VerticalPercent: vertical,
+            OverscanBoundaryCompensation: boundaryCompensation,
+            OverscanBoundaryCompensationStrength: boundaryCompensationStrength,
             CameraSmoothingManaged: smoothingManaged,
             CameraSmoothing: cameraSmoothing,
             SmoothingCrop: smoothingCrop,
@@ -108,6 +111,16 @@ public sealed class OBSMirrorService
         key.SetValue("CameraSmoothingManaged", managed ? 1 : 0, RegistryValueKind.DWord);
         key.SetValue("CameraSmoothing", smoothing, RegistryValueKind.DWord);
         key.SetValue("SmoothingCropTenths", (int)Math.Round(crop * 10.0), RegistryValueKind.DWord);
+    }
+
+    public void ApplyOverscanBoundaryCompensation(bool enabled, int strength)
+    {
+        strength = Math.Clamp(strength, 0, 100);
+
+        using var key = Registry.CurrentUser.CreateSubKey(ConfigKey, writable: true)
+            ?? throw new InvalidOperationException("Could not open the per-user OBSMirror settings key.");
+        key.SetValue("OverscanBoundaryCompensation", enabled ? 1 : 0, RegistryValueKind.DWord);
+        key.SetValue("OverscanBoundaryCompensationStrength", strength, RegistryValueKind.DWord);
     }
 
     public void ApplyMirrorQuadLayers(bool visible)
@@ -233,6 +246,17 @@ public sealed class OBSMirrorService
         var smoothing = Math.Clamp(Convert.ToInt32(key?.GetValue("CameraSmoothing", 35) ?? 35), 0, 100);
         var cropTenths = Math.Clamp(Convert.ToInt32(key?.GetValue("SmoothingCropTenths", 80) ?? 80), 0, 250);
         return (managed, smoothing, cropTenths / 10.0);
+    }
+
+    private (bool Enabled, int Strength) ReadOverscanBoundaryCompensation()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(ConfigKey);
+        var enabled = Convert.ToInt32(key?.GetValue("OverscanBoundaryCompensation", 0) ?? 0) != 0;
+        var strength = Math.Clamp(
+            Convert.ToInt32(key?.GetValue("OverscanBoundaryCompensationStrength", 100) ?? 100),
+            0,
+            100);
+        return (enabled, strength);
     }
 
     private bool ReadMirrorQuadLayers()
@@ -498,8 +522,16 @@ public sealed class OBSMirrorService
         var current = new DirectoryInfo(AppContext.BaseDirectory);
         while (current is not null)
         {
-            if (File.Exists(Path.Combine(current.FullName, "scripts", "Setup-OBS.ps1")) &&
-                File.Exists(Path.Combine(current.FullName, "OpenXR-Layer-OBSMirror.sln")))
+            var setupScript = Path.Combine(current.FullName, "scripts", "Setup-OBS.ps1");
+            var sourceMarker = Path.Combine(current.FullName, "OpenXR-Layer-OBSMirror.sln");
+            var releaseMarker = Path.Combine(
+                current.FullName,
+                "bin",
+                "x64",
+                "Release",
+                "XR_APILAYER_NOVENDOR_OBSMirror.dll");
+            if (File.Exists(setupScript) &&
+                (File.Exists(sourceMarker) || File.Exists(releaseMarker)))
                 return current.FullName;
             current = current.Parent;
         }

--- a/ControlCenter/app.manifest
+++ b/ControlCenter/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="OBSMirror.ControlCenter.app" />
+  <assemblyIdentity version="0.3.0.1" name="OBSMirror.ControlCenter.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/Launch OpenXR OBS Mirror.cmd
+++ b/Launch OpenXR OBS Mirror.cmd
@@ -1,0 +1,2 @@
+@echo off
+start "" "%~dp0ControlCenter\OBSMirror.ControlCenter.exe"

--- a/OBSPlugin/win-openxr/win-openxr.cpp
+++ b/OBSPlugin/win-openxr/win-openxr.cpp
@@ -66,6 +66,7 @@ struct win_openxrmirror {
 	HANDLE map_file = nullptr;
 	obs_mirror_ipc::MirrorSurfaceData *surface = nullptr;
 	std::uint64_t shared_handle = 0;
+	std::uint32_t surface_generation = 0;
 
 	int captureeye = 1; // left = 0, right = 1, both = 2
 	int croppreset;
@@ -169,6 +170,7 @@ static void win_openxrmirror_deinit(void *data)
 	context->device_width = 0;
 	context->device_height = 0;
 	context->shared_handle = 0;
+	context->surface_generation = 0;
 
 	if (context->surface) {
 		UnmapViewOfFile(context->surface);
@@ -249,8 +251,10 @@ static void win_openxrmirror_init(void *data, bool forced = false)
         }
 
         context->mirror_textures = std::vector<winrt::com_ptr<ID3D11Texture2D>>();
+        const std::uint32_t published_generation =
+            context->surface->surfaceGeneration.load(std::memory_order_acquire);
         const std::uint64_t published_handle = context->surface->sharedHandle[0];
-        if (published_handle == 0) {
+        if (published_generation == 0 || published_handle == 0) {
 			// The layer publishes handles after the application's first usable
 			// swapchain image. This is an expected transient state, not an error.
             return;
@@ -284,11 +288,13 @@ static void win_openxrmirror_init(void *data, bool forced = false)
             context->mirror_textures.push_back(mirror_texture);
         }
         MemoryBarrier();
-        if (context->surface->sharedHandle[0] != published_handle) {
+        if (context->surface->sharedHandle[0] != published_handle ||
+            context->surface->surfaceGeneration.load(std::memory_order_acquire) != published_generation) {
             warn("win_openxrmirror_init: Mirror surface changed during initialization");
             return;
         }
         context->shared_handle = published_handle;
+        context->surface_generation = published_generation;
 
         D3D11_TEXTURE2D_DESC desc;
         context->mirror_textures[0]->GetDesc(&desc);
@@ -506,7 +512,11 @@ static void win_openxrmirror_render(void *data, gs_effect_t *effect)
 	struct win_openxrmirror *context = (win_openxrmirror *)data;
 
 	if (context->initialized && context->surface &&
-	    context->shared_handle != context->surface->sharedHandle[0]) {
+	    (context->shared_handle != context->surface->sharedHandle[0] ||
+	     context->surface_generation !=
+	         context->surface->surfaceGeneration.load(std::memory_order_acquire))) {
+		info("Mirror surface changed; reconnecting to generation %u",
+		     context->surface->surfaceGeneration.load(std::memory_order_relaxed));
 		win_openxrmirror_deinit(data);
 	}
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,52 @@
 # OpenXR OBS Mirror
 
-An OpenXR API layer that mirrors a VR application's rendered view into an OBS
-source. The current implementation supports Direct3D 11 OpenXR applications.
+**Capture the application-rendered OpenXR view directly in OBS Studio, with a
+wider, steadier recording camera while the headset continues to look and track
+normally.**
+
+OpenXR OBS Mirror combines a native OpenXR API layer, an OBS source, and a
+self-contained dark WinUI 3 Control Center. It supports Direct3D 11 and
+Direct3D 12 OpenXR applications on Windows x64 and keeps the machine's normal
+headset runtime as the default.
+
+Key recording controls include:
+
+- recording-only FOV overscan with an unchanged headset center crop;
+- live camera smoothing and crop margin;
+- optional matching for fullscreen-effect edges exposed by overscan;
+- independent show/hide control for OpenXR composition quad layers;
+- live runtime, layer, plugin, hash, and diagnostic-log status.
 
 The OpenXR layer template was based on
 [OpenXR-Layer-Template](https://github.com/mbucchia/OpenXR-Layer-Template).
 
-## Install a release
+## Quick install
 
-1. Download and extract the newest compatible release.
-2. Close OBS.
-3. Copy the release's `OBS_Plugin/data` and `OBS_Plugin/obs-plugins`
-   directories into the OBS installation directory (normally
-   `C:\Program Files\obs-studio`).
-4. Run `Install-Layer.ps1` from the extracted layer directory.
-5. Restart OBS and add an **OpenXR Mirror Capture** source.
+1. Open the [latest GitHub release](https://github.com/elliotttate/OpenXR-Layer-OBSMirror/releases/latest).
+2. Close OBS Studio and any running OpenXR application.
+3. Download and run the `OpenXR-OBSMirror-...-Setup.exe` installer.
+4. Open OBS Studio, add an **OpenXR Mirror Capture** source, and start the
+   OpenXR application normally through your headset software.
 
-The install script defaults to a current-user OpenXR registration and does not
-need elevation. Use `-Scope AllUsers` from an elevated PowerShell session only
-when a machine-wide registration is required. The matching uninstall command
-is:
+Setup installs the matching OBS source, registers the layer for the current
+user, adds Start menu integration, and opens Control Center. It does **not**
+select a simulator or replace the system OpenXR runtime. The administrator
+prompt is used to place the OBS source in OBS Studio's shared plugin folder.
+
+Prefer a portable install? Extract the complete portable ZIP, double-click
+`Launch OpenXR OBS Mirror.cmd`, then use **Install / update** in Control Center.
+The app includes its .NET and Windows App SDK runtime files.
+
+See [docs/INSTALL.md](docs/INSTALL.md) for complete setup, update, uninstall,
+recording-control, and troubleshooting instructions. Verify downloads against
+the release's `SHA256SUMS.txt`; current builds are unsigned and may trigger a
+Windows SmartScreen warning.
+
+Manual current-user layer unregistration is also available:
 
 ```powershell
-pwsh -File .\Uninstall-Layer.ps1 -Scope CurrentUser
+pwsh -File .\scripts\Uninstall-Layer.ps1 -Scope CurrentUser
 ```
-
-Do not loosen the machine or user PowerShell execution policy. If Windows has
-marked a downloaded archive as blocked, unblock the archive before extracting
-it or invoke the individual trusted script with `pwsh -ExecutionPolicy Bypass`.
 
 ## Build and install from source
 
@@ -62,8 +81,9 @@ With OBS closed, install both freshly built components for the current user:
 pwsh -File .\scripts\Setup-OBS.ps1
 ```
 
-To stage a first-time install without interrupting an active OBS recording, add
-`-AllowRunningOBS`; the new source will become available after OBS restarts.
+To update the hash-versioned layer without interrupting active OBS, add
+`-AllowRunningOBS`. If the plugin binary also changed, close OBS and run setup
+again so the new source can be copied safely.
 
 This places the layer under `%LOCALAPPDATA%\OpenXR-OBSMirror`, registers its
 manifest under `HKCU\Software\Khronos\OpenXR\1\ApiLayers\Implicit`, and
@@ -74,8 +94,8 @@ installs the plugin under OBS's Windows discovery path at
 
 The dark WinUI 3 Control Center provides one place to inspect layer, plugin,
 runtime, and OBS status; install or update both components; register the layer;
-configure recording overscan; control camera smoothing; show or hide OpenXR
-quad-layer UI in the recording; and read live logs.
+configure recording overscan and guard-band matching; control camera smoothing;
+show or hide OpenXR quad-layer UI in the recording; and read live logs.
 It is headset-first: the dashboard shows the effective runtime, warns when a
 simulator override is active, and provides **Use headset runtime** to clear
 per-user simulator selectors and return to the machine-wide OpenXR runtime.
@@ -86,10 +106,20 @@ Build a self-contained x64 copy:
 pwsh -File .\scripts\Build-ControlCenter.ps1
 ```
 
+Build the native layer, matching OBS 32.2.1 source, Control Center, installer,
+portable ZIP, and checksums in one reproducible command:
+
+```powershell
+pwsh -File .\scripts\Build-Release.ps1 `
+  -Version 0.3.0-beta.1 `
+  -OBSSourcePath E:\Github\obs-studio
+```
+
 Run `bin\x64\Release\ControlCenter\OBSMirror.ControlCenter.exe`. Overscan
 changes apply when the OpenXR application next starts. Camera-smoothing changes
 are picked up live by an active OBS Mirror source. Quad-layer visibility is
-picked up live by the updated OpenXR layer after it has been loaded once.
+picked up live by the updated OpenXR layer after it has been loaded once, as is
+overscan boundary matching.
 
 ## Runtime notes
 
@@ -142,6 +172,14 @@ after changing it. Caveats:
 - Applications that ignore `xrLocateViews` FOVs or the recommended render resolution
   fall back to normal behaviour automatically (their submissions pass through
   unmodified).
+- A projection-baked fullscreen blur, tint, vignette, or fade can be authored as
+  a finite surface that covers only the headset-native FOV. This reveals a hard
+  edge in the added recording perimeter even though the headset looks uniform.
+  Turn on **Match fullscreen effects at the FOV boundary** in Control Center to
+  sample the color change across that known boundary and extend it into the
+  recording guard band. The strength is adjustable, applies live, and never
+  changes the image submitted to the headset. Leave it off when an application
+  does not need the compatibility correction.
 
 ## Camera smoothing (experimental)
 

--- a/XR_APILAYER_NOVENDOR_OBSMirror/XR_APILAYER_NOVENDOR_OBSMirror.json
+++ b/XR_APILAYER_NOVENDOR_OBSMirror/XR_APILAYER_NOVENDOR_OBSMirror.json
@@ -4,8 +4,8 @@
     "name": "XR_APILAYER_NOVENDOR_OBSMirror",
     "library_path": ".\\XR_APILAYER_NOVENDOR_OBSMirror.dll",
     "api_version": "1.0",
-    "implementation_version": "1",
-    "description": "OpenXR API layer to provide output for OBS OpenXR Plugin",
+    "implementation_version": "3",
+    "description": "Headset-safe OpenXR mirror capture for OBS Studio",
     "functions": {
       "xrNegotiateLoaderApiLayerInterface": "xrNegotiateLoaderApiLayerInterface"
     },

--- a/XR_APILAYER_NOVENDOR_OBSMirror/XR_APILAYER_NOVENDOR_OBSMirror_32.json
+++ b/XR_APILAYER_NOVENDOR_OBSMirror/XR_APILAYER_NOVENDOR_OBSMirror_32.json
@@ -4,8 +4,8 @@
     "name": "XR_APILAYER_NOVENDOR_OBSMirror",
     "library_path": ".\\XR_APILAYER_NOVENDOR_OBSMirror_32.dll",
     "api_version": "1.0",
-    "implementation_version": "1",
-    "description": "OpenXR API layer to provide output for OBS OpenXR Plugin (32-bit)",
+    "implementation_version": "3",
+    "description": "Headset-safe OpenXR mirror capture for OBS Studio (32-bit)",
     "functions": {
       "xrNegotiateLoaderApiLayerInterface": "_xrNegotiateLoaderApiLayerInterface@12"
     },

--- a/XR_APILAYER_NOVENDOR_OBSMirror/dx11mirror.cpp
+++ b/XR_APILAYER_NOVENDOR_OBSMirror/dx11mirror.cpp
@@ -89,6 +89,10 @@ namespace Mirror {
         float blendEndX;
         float texIndex; // Ignored by the non-array shader
         float alphaOverride;
+        XMFLOAT4 overscanBounds; // left, right, top, bottom in source UVs
+        XMFLOAT2 sourceTexelSize;
+        float overscanCompensation;
+        float overscanSampleRadius;
     };
 
     constexpr char quad_vs_code[] = R"_(
@@ -127,6 +131,10 @@ cbuffer PSConstants : register(b1) // Use a different register for PS constants
     float blendEndX;
     float texIndex; // Unused here; keeps the layout shared with the array shader
     float alphaOverride;
+    float4 overscanBounds;
+    float2 sourceTexelSize;
+    float overscanCompensation;
+    float overscanSampleRadius;
 };
 
 Texture2D shaderTexture : register(t0);
@@ -138,9 +146,73 @@ struct psIn {
 	float2 tex : TEXCOORD0;
 };
 
+float3 boundaryAverage(float2 uv, float2 alongStep)
+{
+    float3 sum = 0.0;
+    [unroll]
+    for (int i = -2; i <= 2; ++i)
+        sum += shaderTexture.Sample(SampleType, saturate(uv + alongStep * i)).rgb;
+    return sum / 5.0;
+}
+
+float3 matchOverscanGuardBand(float2 uv, float3 color)
+{
+    if (overscanCompensation <= 0.001)
+        return color;
+
+    float leftPx = (overscanBounds.x - uv.x) / max(sourceTexelSize.x, 0.000001);
+    float rightPx = (uv.x - overscanBounds.y) / max(sourceTexelSize.x, 0.000001);
+    float topPx = (overscanBounds.z - uv.y) / max(sourceTexelSize.y, 0.000001);
+    float bottomPx = (uv.y - overscanBounds.w) / max(sourceTexelSize.y, 0.000001);
+
+    int edge = -1;
+    float nearestPx = 1000000.0;
+    if (leftPx > 0.0 && leftPx < nearestPx) { edge = 0; nearestPx = leftPx; }
+    if (rightPx > 0.0 && rightPx < nearestPx) { edge = 1; nearestPx = rightPx; }
+    if (topPx > 0.0 && topPx < nearestPx) { edge = 2; nearestPx = topPx; }
+    if (bottomPx > 0.0 && bottomPx < nearestPx) { edge = 3; nearestPx = bottomPx; }
+    if (edge < 0)
+        return color;
+
+    float radius = max(overscanSampleRadius, 1.0);
+    float2 outerUv;
+    float2 innerUv;
+    float2 alongStep;
+    if (edge < 2) {
+        float safeY = clamp(uv.y,
+                            overscanBounds.z + sourceTexelSize.y * 6.0,
+                            overscanBounds.w - sourceTexelSize.y * 6.0);
+        float boundaryX = edge == 0 ? overscanBounds.x : overscanBounds.y;
+        float direction = edge == 0 ? 1.0 : -1.0;
+        outerUv = float2(boundaryX - direction * sourceTexelSize.x * radius, safeY);
+        innerUv = float2(boundaryX + direction * sourceTexelSize.x * radius, safeY);
+        alongStep = float2(0.0, sourceTexelSize.y * 2.0);
+    } else {
+        float safeX = clamp(uv.x,
+                            overscanBounds.x + sourceTexelSize.x * 6.0,
+                            overscanBounds.y - sourceTexelSize.x * 6.0);
+        float boundaryY = edge == 2 ? overscanBounds.z : overscanBounds.w;
+        float direction = edge == 2 ? 1.0 : -1.0;
+        outerUv = float2(safeX, boundaryY - direction * sourceTexelSize.y * radius);
+        innerUv = float2(safeX, boundaryY + direction * sourceTexelSize.y * radius);
+        alongStep = float2(sourceTexelSize.x * 2.0, 0.0);
+    }
+
+    float3 outsideColor = boundaryAverage(outerUv, alongStep);
+    float3 insideColor = boundaryAverage(innerUv, alongStep);
+    const float epsilon = 0.02;
+    float3 channelGain = clamp((insideColor + epsilon) / (outsideColor + epsilon), 0.60, 1.40);
+    float outsideLuma = dot(outsideColor, float3(0.2126, 0.7152, 0.0722));
+    float insideLuma = dot(insideColor, float3(0.2126, 0.7152, 0.0722));
+    float lumaGain = clamp((insideLuma + epsilon) / (outsideLuma + epsilon), 0.60, 1.40);
+    float3 stableGain = lerp(lumaGain.xxx, channelGain, 0.50);
+    return color * lerp(1.0.xxx, stableGain, saturate(overscanCompensation));
+}
+
 float4 ps_quad(psIn inputPS) : SV_TARGET
 {
 	float4 textureColor = shaderTexture.Sample(SampleType, inputPS.tex);
+	textureColor.rgb = matchOverscanGuardBand(inputPS.tex, textureColor.rgb);
 
     // Calculate the horizontal blend factor based on texture coordinate x
     // smoothstep provides a nice S-curve interpolation between the start and end points.
@@ -165,6 +237,10 @@ cbuffer PSConstants : register(b1) // Use a different register for PS constants
     float blendEndX;
     float texIndex;
     float alphaOverride;
+    float4 overscanBounds;
+    float2 sourceTexelSize;
+    float overscanCompensation;
+    float overscanSampleRadius;
 };
 
 Texture2DArray shaderTexture : register(t0);
@@ -175,12 +251,76 @@ struct psIn {
 	float2 tex : TEXCOORD0;
 };
 
+float3 boundaryAverage(float2 uv, float2 alongStep)
+{
+    float3 sum = 0.0;
+    [unroll]
+    for (int i = -2; i <= 2; ++i)
+        sum += shaderTexture.Sample(SampleType, float3(saturate(uv + alongStep * i), texIndex)).rgb;
+    return sum / 5.0;
+}
+
+float3 matchOverscanGuardBand(float2 uv, float3 color)
+{
+    if (overscanCompensation <= 0.001)
+        return color;
+
+    float leftPx = (overscanBounds.x - uv.x) / max(sourceTexelSize.x, 0.000001);
+    float rightPx = (uv.x - overscanBounds.y) / max(sourceTexelSize.x, 0.000001);
+    float topPx = (overscanBounds.z - uv.y) / max(sourceTexelSize.y, 0.000001);
+    float bottomPx = (uv.y - overscanBounds.w) / max(sourceTexelSize.y, 0.000001);
+
+    int edge = -1;
+    float nearestPx = 1000000.0;
+    if (leftPx > 0.0 && leftPx < nearestPx) { edge = 0; nearestPx = leftPx; }
+    if (rightPx > 0.0 && rightPx < nearestPx) { edge = 1; nearestPx = rightPx; }
+    if (topPx > 0.0 && topPx < nearestPx) { edge = 2; nearestPx = topPx; }
+    if (bottomPx > 0.0 && bottomPx < nearestPx) { edge = 3; nearestPx = bottomPx; }
+    if (edge < 0)
+        return color;
+
+    float radius = max(overscanSampleRadius, 1.0);
+    float2 outerUv;
+    float2 innerUv;
+    float2 alongStep;
+    if (edge < 2) {
+        float safeY = clamp(uv.y,
+                            overscanBounds.z + sourceTexelSize.y * 6.0,
+                            overscanBounds.w - sourceTexelSize.y * 6.0);
+        float boundaryX = edge == 0 ? overscanBounds.x : overscanBounds.y;
+        float direction = edge == 0 ? 1.0 : -1.0;
+        outerUv = float2(boundaryX - direction * sourceTexelSize.x * radius, safeY);
+        innerUv = float2(boundaryX + direction * sourceTexelSize.x * radius, safeY);
+        alongStep = float2(0.0, sourceTexelSize.y * 2.0);
+    } else {
+        float safeX = clamp(uv.x,
+                            overscanBounds.x + sourceTexelSize.x * 6.0,
+                            overscanBounds.y - sourceTexelSize.x * 6.0);
+        float boundaryY = edge == 2 ? overscanBounds.z : overscanBounds.w;
+        float direction = edge == 2 ? 1.0 : -1.0;
+        outerUv = float2(safeX, boundaryY - direction * sourceTexelSize.y * radius);
+        innerUv = float2(safeX, boundaryY + direction * sourceTexelSize.y * radius);
+        alongStep = float2(sourceTexelSize.x * 2.0, 0.0);
+    }
+
+    float3 outsideColor = boundaryAverage(outerUv, alongStep);
+    float3 insideColor = boundaryAverage(innerUv, alongStep);
+    const float epsilon = 0.02;
+    float3 channelGain = clamp((insideColor + epsilon) / (outsideColor + epsilon), 0.60, 1.40);
+    float outsideLuma = dot(outsideColor, float3(0.2126, 0.7152, 0.0722));
+    float insideLuma = dot(insideColor, float3(0.2126, 0.7152, 0.0722));
+    float lumaGain = clamp((insideLuma + epsilon) / (outsideLuma + epsilon), 0.60, 1.40);
+    float3 stableGain = lerp(lumaGain.xxx, channelGain, 0.50);
+    return color * lerp(1.0.xxx, stableGain, saturate(overscanCompensation));
+}
+
 float4 ps_quad(psIn inputPS) : SV_TARGET
 {
     // Combine UV coords with the desired array slice index
     float3 sampleCoord = float3(inputPS.tex.x, inputPS.tex.y, texIndex);
 
 	float4 textureColor = shaderTexture.Sample(SampleType, sampleCoord);
+	textureColor.rgb = matchOverscanGuardBand(inputPS.tex, textureColor.rgb);
 
     // Calculate the horizontal blend factor based on texture coordinate x
     // smoothstep provides a nice S-curve interpolation between the start and end points.
@@ -683,11 +823,13 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
     }
 
     void D3D11Mirror::drawSmoothedEye(const XrCompositionLayerProjectionView* view,
+                                      const XrFovf& hmdFov,
                                       const SourceData& src,
                                       const XrRect2Di& targetRect,
                                       const bool seamBlend,
                                       const float alphaOverride,
-                                      const XrTime displayTime) {
+                                      const XrTime displayTime,
+                                      const XrFovf* nativeFov) {
         D3D11_TEXTURE2D_DESC srcDesc;
         src._texture->GetDesc(&srcDesc);
 
@@ -707,7 +849,7 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
             blendEndX = std::min(uv.endX, uv.startX + ((_pMirrorSurfaceData->blendPos + blendOffset) * blendWidth));
         }
         const float texIndex = srcDesc.ArraySize > 1 ? static_cast<float>(view->subImage.imageArrayIndex) : 0.0f;
-        writeBlendConstants(blendStartX, blendEndX, texIndex, alphaOverride);
+        writeBlendConstants(blendStartX, blendEndX, texIndex, alphaOverride, uv, srcDesc, &view->fov, nativeFov);
         bindQuadPipeline(src);
         setTargetRect(targetRect);
 
@@ -820,12 +962,124 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
         return uv;
     }
 
-    void D3D11Mirror::writeBlendConstants(float blendStartX, float blendEndX, float texIndex, float alphaOverride) {
-        quad_blend_buffer_t psCB1;
+    void D3D11Mirror::refreshOverscanCompensationConfig() {
+        const ULONGLONG now = GetTickCount64();
+        if (_overscanCompensationConfigInitialized &&
+            now - _lastOverscanCompensationConfigCheckTick < 250)
+            return;
+        _lastOverscanCompensationConfigCheckTick = now;
+
+        DWORD enabled = 0;
+        DWORD strength = 100;
+        HKEY key = nullptr;
+        if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\OpenXR-OBSMirror", 0, KEY_QUERY_VALUE, &key) ==
+            ERROR_SUCCESS) {
+            DWORD size = sizeof(DWORD);
+            RegQueryValueExW(key,
+                             L"OverscanBoundaryCompensation",
+                             nullptr,
+                             nullptr,
+                             reinterpret_cast<BYTE*>(&enabled),
+                             &size);
+            size = sizeof(DWORD);
+            RegQueryValueExW(key,
+                             L"OverscanBoundaryCompensationStrength",
+                             nullptr,
+                             nullptr,
+                             reinterpret_cast<BYTE*>(&strength),
+                             &size);
+            RegCloseKey(key);
+        }
+
+        const bool active = enabled != 0;
+        const float normalizedStrength = static_cast<float>(std::clamp<DWORD>(strength, 0, 100)) / 100.0f;
+        if (!_overscanCompensationConfigInitialized || active != _overscanCompensation ||
+            fabsf(normalizedStrength - _overscanCompensationStrength) > 0.001f) {
+            Log("Recording overscan boundary matching: %s at %.0f%% strength\n",
+                active ? "enabled" : "disabled",
+                normalizedStrength * 100.0f);
+            _overscanCompensationAppliedLogged = false;
+        }
+        _overscanCompensation = active;
+        _overscanCompensationStrength = normalizedStrength;
+        _overscanCompensationConfigInitialized = true;
+    }
+
+    bool D3D11Mirror::computeOverscanBounds(const XrFovf& renderedFov,
+                                            const XrFovf& headsetFov,
+                                            const UVRect& uv,
+                                            XMFLOAT4& bounds) const {
+        const float renderedLeft = tanf(renderedFov.angleLeft);
+        const float renderedRight = tanf(renderedFov.angleRight);
+        const float renderedDown = tanf(renderedFov.angleDown);
+        const float renderedUp = tanf(renderedFov.angleUp);
+        const float headsetLeft = tanf(headsetFov.angleLeft);
+        const float headsetRight = tanf(headsetFov.angleRight);
+        const float headsetDown = tanf(headsetFov.angleDown);
+        const float headsetUp = tanf(headsetFov.angleUp);
+
+        const float spanX = renderedRight - renderedLeft;
+        const float spanY = renderedUp - renderedDown;
+        if (spanX <= 0.0001f || spanY <= 0.0001f)
+            return false;
+
+        // The game-rendered FOV must contain the runtime-native headset FOV.
+        // If it does not, this is a normal non-overscan projection and the
+        // correction stays out of the way.
+        constexpr float containmentEpsilon = 0.001f;
+        if (renderedLeft > headsetLeft + containmentEpsilon ||
+            renderedRight < headsetRight - containmentEpsilon ||
+            renderedDown > headsetDown + containmentEpsilon ||
+            renderedUp < headsetUp - containmentEpsilon)
+            return false;
+
+        const float left = std::clamp((headsetLeft - renderedLeft) / spanX, 0.0f, 1.0f);
+        const float right = std::clamp((headsetRight - renderedLeft) / spanX, 0.0f, 1.0f);
+        const float top = std::clamp((renderedUp - headsetUp) / spanY, 0.0f, 1.0f);
+        const float bottom = std::clamp((renderedUp - headsetDown) / spanY, 0.0f, 1.0f);
+        if (left < 0.0005f && right > 0.9995f && top < 0.0005f && bottom > 0.9995f)
+            return false;
+
+        const float uvWidth = uv.endX - uv.startX;
+        const float uvHeight = uv.endY - uv.startY;
+        bounds = {uv.startX + left * uvWidth,
+                  uv.startX + right * uvWidth,
+                  uv.startY + top * uvHeight,
+                  uv.startY + bottom * uvHeight};
+        return bounds.x < bounds.y && bounds.z < bounds.w;
+    }
+
+    void D3D11Mirror::writeBlendConstants(float blendStartX,
+                                          float blendEndX,
+                                          float texIndex,
+                                          float alphaOverride,
+                                          const UVRect& uv,
+                                          const D3D11_TEXTURE2D_DESC& srcDesc,
+                                          const XrFovf* renderedFov,
+                                          const XrFovf* headsetFov) {
+        refreshOverscanCompensationConfig();
+
+        quad_blend_buffer_t psCB1{};
         psCB1.blendStartX = blendStartX;
         psCB1.blendEndX = blendEndX;
         psCB1.texIndex = texIndex;
         psCB1.alphaOverride = alphaOverride;
+        psCB1.overscanBounds = {uv.startX, uv.endX, uv.startY, uv.endY};
+        psCB1.sourceTexelSize = {1.0f / static_cast<float>(std::max(srcDesc.Width, 1u)),
+                                 1.0f / static_cast<float>(std::max(srcDesc.Height, 1u))};
+        psCB1.overscanSampleRadius = 3.0f;
+        if (_overscanCompensation && _overscanCompensationStrength > 0.0f && renderedFov && headsetFov &&
+            computeOverscanBounds(*renderedFov, *headsetFov, uv, psCB1.overscanBounds)) {
+            psCB1.overscanCompensation = _overscanCompensationStrength;
+            if (!_overscanCompensationAppliedLogged) {
+                Log("Recording overscan boundary matching applied: UV %.4f,%.4f x %.4f,%.4f\n",
+                    psCB1.overscanBounds.x,
+                    psCB1.overscanBounds.y,
+                    psCB1.overscanBounds.z,
+                    psCB1.overscanBounds.w);
+                _overscanCompensationAppliedLogged = true;
+            }
+        }
 
         D3D11_MAPPED_SUBRESOURCE mapped{};
         CHECK_DX(_d3d11MirrorContext->Map(_quadConstantBlendBuffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
@@ -903,8 +1157,13 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
         if (!lock.acquired())
             return;
 
-        writeQuadUVs(quad->subImage.imageRect, srcDesc);
-        writeBlendConstants(0.0f, 0.0f, static_cast<float>(quad->subImage.imageArrayIndex), 0.0f);
+        const UVRect quadUv = writeQuadUVs(quad->subImage.imageRect, srcDesc);
+        writeBlendConstants(0.0f,
+                            0.0f,
+                            static_cast<float>(quad->subImage.imageArrayIndex),
+                            0.0f,
+                            quadUv,
+                            srcDesc);
         bindQuadPipeline(it->second);
 
         XrRect2Di rect = {{0, 0}, {static_cast<int32_t>(_comp_desc.Width), static_cast<int32_t>(_comp_desc.Height)}};
@@ -969,13 +1228,18 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
                             const XrFovf& hmdFov,
                             const DXGI_FORMAT format,
                             const XrSpace viewSpace,
-                            const XrTime displayTime) {
+                            const XrTime displayTime,
+                            const XrFovf* nativeFov) {
         if (!_initialized)
             return;
 
         const bool smoothing = smoothingActive();
+        XMFLOAT4 compensationBounds{};
+        const bool compensateOverscan =
+            _overscanCompensation && nativeFov &&
+            computeOverscanBounds(view->fov, *nativeFov, {0.0f, 1.0f, 0.0f, 1.0f}, compensationBounds);
 
-        if (!smoothing && XMScalarNearEqual(hmdFov.angleDown, view->fov.angleDown, 0.001f) &&
+        if (!smoothing && !compensateOverscan && XMScalarNearEqual(hmdFov.angleDown, view->fov.angleDown, 0.001f) &&
             XMScalarNearEqual(hmdFov.angleUp, view->fov.angleUp, 0.001f) &&
             XMScalarNearEqual(hmdFov.angleLeft, view->fov.angleLeft, 0.001f) &&
             XMScalarNearEqual(hmdFov.angleRight, view->fov.angleRight, 0.001f))
@@ -996,7 +1260,7 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
 
         if (smoothing) {
             const XrRect2Di rect = {{0, 0}, view->subImage.imageRect.extent};
-            drawSmoothedEye(view, it->second, rect, false, 1.0f, displayTime);
+            drawSmoothedEye(view, hmdFov, it->second, rect, false, 1.0f, displayTime, nativeFov);
             return;
         }
 
@@ -1008,10 +1272,10 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
         if (!lock.acquired())
             return;
 
-        writeQuadUVs(view->subImage.imageRect, srcDesc);
+        const UVRect uv = writeQuadUVs(view->subImage.imageRect, srcDesc);
 
         const float texIndex = srcDesc.ArraySize > 1 ? static_cast<float>(view->subImage.imageArrayIndex) : 0.0f;
-        writeBlendConstants(0.0f, 0.0f, texIndex, 1.0f);
+        writeBlendConstants(0.0f, 0.0f, texIndex, 1.0f, uv, srcDesc, &view->fov, nativeFov);
         bindQuadPipeline(it->second);
 
         XrRect2Di rect = {{0, 0}, view->subImage.imageRect.extent};
@@ -1027,7 +1291,9 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
                             const XrFovf& hmdFov2,
                             const DXGI_FORMAT format,
                             const XrSpace viewSpace,
-                            const XrTime displayTime) {
+                            const XrTime displayTime,
+                            const XrFovf* nativeFov1,
+                            const XrFovf* nativeFov2) {
         if (!_initialized)
             return;
 
@@ -1047,13 +1313,17 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
             return;
 
         const bool smoothing = smoothingActive();
+        XMFLOAT4 compensationBounds{};
+        const bool compensateOverscan1 =
+            _overscanCompensation && nativeFov1 &&
+            computeOverscanBounds(view1->fov, *nativeFov1, {0.0f, 1.0f, 0.0f, 1.0f}, compensationBounds);
 
         // First eye
         if (smoothing) {
             const XrRect2Di rect = {{0, 0}, view1->subImage.imageRect.extent};
-            drawSmoothedEye(view1, it1->second, rect, false, 0.0f, displayTime);
+            drawSmoothedEye(view1, hmdFov1, it1->second, rect, false, 0.0f, displayTime, nativeFov1);
         }
-        else if (XMScalarNearEqual(hmdFov1.angleDown, view1->fov.angleDown, 0.001f) &&
+        else if (!compensateOverscan1 && XMScalarNearEqual(hmdFov1.angleDown, view1->fov.angleDown, 0.001f) &&
             XMScalarNearEqual(hmdFov1.angleUp, view1->fov.angleUp, 0.001f) &&
             XMScalarNearEqual(hmdFov1.angleLeft, view1->fov.angleLeft, 0.001f) &&
             XMScalarNearEqual(hmdFov1.angleRight, view1->fov.angleRight, 0.001f))
@@ -1069,11 +1339,11 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
             syncToSource(it1->second);
             ScopedKeyedMutex lock(it1->second._keyedMutex.Get());
             if (lock.acquired()) {
-                writeQuadUVs(view1->subImage.imageRect, srcDesc);
+                const UVRect uv = writeQuadUVs(view1->subImage.imageRect, srcDesc);
 
                 const float texIndex =
                     srcDesc.ArraySize > 1 ? static_cast<float>(view1->subImage.imageArrayIndex) : 0.0f;
-                writeBlendConstants(0.0f, 0.0f, texIndex, 0.0f);
+                writeBlendConstants(0.0f, 0.0f, texIndex, 0.0f, uv, srcDesc, &view1->fov, nativeFov1);
                 bindQuadPipeline(it1->second);
 
                 XrRect2Di rect = {{0, 0}, view1->subImage.imageRect.extent};
@@ -1089,7 +1359,7 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
             XrRect2Di rect = {{0, 0}, view2->subImage.imageRect.extent};
             rect.offset.x =
                 rect.offset.x + static_cast<int32_t>((rect.extent.width * _pMirrorSurfaceData->overlap) / 100);
-            drawSmoothedEye(view2, it2->second, rect, true, 1.0f, displayTime);
+            drawSmoothedEye(view2, hmdFov2, it2->second, rect, true, 1.0f, displayTime, nativeFov2);
         } else {
             D3D11_TEXTURE2D_DESC srcDesc;
             it2->second._texture->GetDesc(&srcDesc);
@@ -1108,7 +1378,7 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
             const float blendEndX =
                 std::min(uv.endX, uv.startX + ((_pMirrorSurfaceData->blendPos + blendOffset) * blendWidth));
             const float texIndex = srcDesc.ArraySize > 1 ? static_cast<float>(view2->subImage.imageArrayIndex) : 0.0f;
-            writeBlendConstants(blendStartX, blendEndX, texIndex, 1.0f);
+            writeBlendConstants(blendStartX, blendEndX, texIndex, 1.0f, uv, srcDesc, &view2->fov, nativeFov2);
             bindQuadPipeline(it2->second);
 
             XrRect2Di rect = {{0, 0}, view2->subImage.imageRect.extent};
@@ -1209,6 +1479,11 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
         if (!needsRebuild)
             return;
 
+        uint32_t nextGeneration =
+            _pMirrorSurfaceData->surfaceGeneration.load(std::memory_order_relaxed) + 1;
+        if (nextGeneration == 0)
+            nextGeneration = 1;
+
         // Handle zero is the generation marker. Clear it before releasing or
         // replacing resources, then publish it last after all three handles exist.
         _pMirrorSurfaceData->sharedHandle[0] = 0;
@@ -1278,8 +1553,10 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
             _pMirrorSurfaceData->sharedHandle[i] = newSharedHandles[i];
         MemoryBarrier();
         _pMirrorSurfaceData->sharedHandle[0] = newSharedHandles[0];
+        _pMirrorSurfaceData->surfaceGeneration.store(nextGeneration, std::memory_order_release);
 
-        Log("Compositor texture description: %d x %d Format %d\n",
+        Log("Compositor texture generation %u: %d x %d Format %d\n",
+            nextGeneration,
             _comp_desc.Width,
             _comp_desc.Height,
             _comp_desc.Format);
@@ -1313,6 +1590,12 @@ float4 ps_quad(psIn inputPS) : SV_TARGET
             _obsRunning = false;
             return;
         }
+
+        // Keep recording-only controls live even while the OBS heartbeat is
+        // reconnecting (for example after the VR application restarts). If
+        // this refresh only happens in writeBlendConstants(), a stale
+        // heartbeat prevents the draw that would have refreshed the setting.
+        refreshOverscanCompensationConfig();
 
         const uint32_t frameNumber = _pMirrorSurfaceData->frameNumber;
         if (_lastOBSFrameNumber == frameNumber) {

--- a/XR_APILAYER_NOVENDOR_OBSMirror/dx11mirror.h
+++ b/XR_APILAYER_NOVENDOR_OBSMirror/dx11mirror.h
@@ -64,7 +64,8 @@ namespace Mirror
                    const XrFovf& hmdFov,
                    const DXGI_FORMAT format,
                    const XrSpace space,
-                   const XrTime displayTime);
+                   const XrTime displayTime,
+                   const XrFovf* nativeFov = nullptr);
 
         void Blend(const XrCompositionLayerProjectionView* view1,
                    const XrFovf& hmdFov1,
@@ -72,7 +73,9 @@ namespace Mirror
                    const XrFovf& hmdFov2,
                    const DXGI_FORMAT format,
                    const XrSpace viewSpace,
-                   const XrTime displayTime);
+                   const XrTime displayTime,
+                   const XrFovf* nativeFov1 = nullptr,
+                   const XrFovf* nativeFov2 = nullptr);
 
         void copyPerspectiveTex(const XrRect2Di& imgRect,
                                 const uint32_t arraySlice,
@@ -118,11 +121,13 @@ namespace Mirror
         /// Reprojects one eye image from the smoothed camera with a slight
         /// tan-space crop, absorbing high-frequency head motion.
         void drawSmoothedEye(const XrCompositionLayerProjectionView* view,
+                             const XrFovf& hmdFov,
                              const SourceData& src,
                              const XrRect2Di& targetRect,
                              const bool seamBlend,
                              const float alphaOverride,
-                             const XrTime displayTime);
+                             const XrTime displayTime,
+                             const XrFovf* nativeFov = nullptr);
 
         static XrFovf scaleFovTan(const XrFovf& fov, const float scale);
 
@@ -136,7 +141,21 @@ namespace Mirror
 
         UVRect writeQuadUVs(const XrRect2Di& imgRect, const D3D11_TEXTURE2D_DESC& srcDesc);
 
-        void writeBlendConstants(float blendStartX, float blendEndX, float texIndex, float alphaOverride);
+        void writeBlendConstants(float blendStartX,
+                                 float blendEndX,
+                                 float texIndex,
+                                 float alphaOverride,
+                                 const UVRect& uv,
+                                 const D3D11_TEXTURE2D_DESC& srcDesc,
+                                 const XrFovf* renderedFov = nullptr,
+                                 const XrFovf* headsetFov = nullptr);
+
+        bool computeOverscanBounds(const XrFovf& renderedFov,
+                                   const XrFovf& headsetFov,
+                                   const UVRect& uv,
+                                   DirectX::XMFLOAT4& bounds) const;
+
+        void refreshOverscanCompensationConfig();
 
         void bindQuadPipeline(const SourceData& srcData);
 
@@ -195,5 +214,13 @@ namespace Mirror
         DirectX::XMFLOAT3 _smoothPos{0.0f, 0.0f, 0.0f};
         DirectX::XMFLOAT4 _smoothRelQuat{0.0f, 0.0f, 0.0f, 1.0f};
         DirectX::XMFLOAT3 _smoothRelPos{0.0f, 0.0f, 0.0f};
+
+        // Recording-only correction for finite, projection-baked fullscreen
+        // effects that stop at the runtime-native FOV when overscan is active.
+        bool _overscanCompensation = false;
+        float _overscanCompensationStrength = 1.0f;
+        bool _overscanCompensationConfigInitialized = false;
+        bool _overscanCompensationAppliedLogged = false;
+        ULONGLONG _lastOverscanCompensationConfigCheckTick = 0;
     };
 }

--- a/XR_APILAYER_NOVENDOR_OBSMirror/layer.cpp
+++ b/XR_APILAYER_NOVENDOR_OBSMirror/layer.cpp
@@ -874,15 +874,22 @@ namespace {
                             projLayer = reinterpret_cast<const XrCompositionLayerProjection*>(hdr);
                             if (projLayer->viewCount >= 2) {
                                 if (_mirror->getEyeIndex() < 2) {
-                                    projView = &projLayer->views[_mirror->getEyeIndex()];
+                                    const uint32_t eyeIndex = _mirror->getEyeIndex();
+                                    projView = &projLayer->views[eyeIndex];
                                     if (isSwapchainHandled(projView->subImage.swapchain)) {
                                         auto& swapchainState = _swapchains[projView->subImage.swapchain];
                                         if (swapchainState._dx11LastTexture || swapchainState._dx12LastTexture) {
+                                            const XrFovf& mirrorFov = eyeIndex < _projectionViews.size()
+                                                                                ? _projectionViews[eyeIndex].fov
+                                                                                : _projectionViews[0].fov;
+                                            const XrFovf* nativeFov =
+                                                eyeIndex < _originalViewFovs.size() ? &_originalViewFovs[eyeIndex] : nullptr;
                                             _mirror->Blend(projView,
-                                                           _projectionViews[0].fov,
+                                                           mirrorFov,
                                                            (DXGI_FORMAT)swapchainState._createInfo.format,
                                                            projLayer->space,
-                                                           frameEndInfo->displayTime);
+                                                           frameEndInfo->displayTime,
+                                                           nativeFov);
                                         }
                                     }
                                 } else if (_projectionViews.size() >= 2) {
@@ -900,7 +907,9 @@ namespace {
                                                            _projectionViews[1].fov,
                                                            (DXGI_FORMAT)swapchainState._createInfo.format,
                                                            projLayer->space,
-                                                           frameEndInfo->displayTime);
+                                                           frameEndInfo->displayTime,
+                                                           _originalViewFovs.size() > 0 ? &_originalViewFovs[0] : nullptr,
+                                                           _originalViewFovs.size() > 1 ? &_originalViewFovs[1] : nullptr);
                                         }
                                     }
                                 }

--- a/XR_APILAYER_NOVENDOR_OBSMirror/layer.h
+++ b/XR_APILAYER_NOVENDOR_OBSMirror/layer.h
@@ -27,7 +27,7 @@
 namespace layer_OBSMirror {
 
     const std::string LayerName = "XR_APILAYER_NOVENDOR_OBSMirror";
-    const std::string VersionString = "(v0.2.5)";
+    const std::string VersionString = "v0.3.0-beta.1";
 
     // Singleton accessor.
     OpenXrApi* GetInstance();

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,75 @@
+# OpenXR OBS Mirror installation
+
+OpenXR OBS Mirror captures the application-rendered OpenXR view directly in
+OBS Studio while preserving the headset's normal runtime, view, and tracking.
+
+## Recommended: Windows installer
+
+1. Close OBS Studio and any running OpenXR application.
+2. Run `OpenXR-OBSMirror-0.3.0-beta.1-Setup.exe`.
+3. Accept the Windows administrator prompt. It is used only to place the OBS
+   source in OBS Studio's shared plugin directory.
+4. Leave **Open Control Center** selected and finish setup.
+5. Confirm that **Layer**, **OBS source**, and **Runtime** are green in Control
+   Center.
+6. Open OBS Studio, add an **OpenXR Mirror Capture** source, then start the
+   OpenXR application normally through your headset software.
+
+The installer does not select a simulator or replace the system OpenXR
+runtime. If Control Center reports an inherited simulator override, use
+**Use headset runtime**, then restart any launcher that was already open.
+
+## Portable package
+
+1. Extract the entire ZIP to a permanent folder.
+2. Close OBS Studio.
+3. Double-click `Launch OpenXR OBS Mirror.cmd`.
+4. Open **Installation** and choose **Install / update**.
+5. Restart OBS Studio and add an **OpenXR Mirror Capture** source.
+
+The portable Control Center is self-contained; a separate .NET installation is
+not required. Keep the extracted folder intact because it contains the native
+layer, OBS source, scripts, and app runtime.
+
+## Recording controls
+
+- **Overscan** asks compatible applications to render a wider recording image,
+  while the headset receives its original center view unchanged. Restart the
+  OpenXR application after changing the overscan dimensions.
+- **Match fullscreen effects at the FOV boundary** can extend a projection-baked
+  tint, fade, blur, or vignette into the added recording perimeter. It changes
+  only the OBS mirror and can be adjusted live.
+- **Camera smoothing** filters the recording camera only. Its strength and crop
+  margin update live.
+- **UI layers** can include or omit separately submitted OpenXR quad layers in
+  the recording without changing the headset.
+
+Start with modest overscan such as 115% horizontal and 108% vertical. The GPU
+pixel cost scales approximately with the product of those values.
+
+## Updating and uninstalling
+
+Run a newer installer over the existing version. The OpenXR layer uses an
+immutable, hash-versioned native DLL, so an update can be staged without
+replacing a DLL already loaded by a headset session. Restart the OpenXR
+application to load the new layer. Restart OBS Studio when the OBS source is
+updated.
+
+Use **Installed apps > OpenXR OBS Mirror > Uninstall** to remove the Control
+Center, OBS source, current-user OpenXR layer registration, and installed layer
+files. Close OBS Studio and any OpenXR application first so loaded files can be
+removed immediately.
+
+## Troubleshooting
+
+- A black OBS source normally means no active OpenXR session has published a
+  mirror surface yet. Start the OpenXR application after OBS, or reopen the OBS
+  source properties to reconnect.
+- If OBS was open during an update, close it and run **Install / update** again.
+- If the wrong runtime is listed, use **Use headset runtime** and relaunch the
+  OpenXR application.
+- Check the live layer log on the Control Center **Installation** page for the
+  runtime name, graphics API, swapchain dimensions, and active options.
+- Builds are currently unsigned, so Windows SmartScreen may show an
+  unrecognized-publisher warning. Verify the download against
+  `SHA256SUMS.txt` from the same GitHub release.

--- a/docs/release-notes/v0.3.0-beta.1.md
+++ b/docs/release-notes/v0.3.0-beta.1.md
@@ -1,0 +1,59 @@
+# OpenXR OBS Mirror v0.3.0 Beta 1
+
+This is the first complete, headset-first distribution of OpenXR OBS Mirror: a
+native OpenXR API layer, a matching OBS Studio source, and a self-contained
+dark WinUI 3 Control Center packaged together for Windows x64.
+
+## Highlights
+
+- **One installer, one control surface.** Setup installs the OBS source,
+  registers the OpenXR layer for the current user, and opens Control Center.
+- **Normal headset runtime stays primary.** Opening Control Center never selects
+  a simulator. It reports the effective and system runtimes, warns about stale
+  overrides, and can restore the headset runtime explicitly.
+- **Direct3D 11 and Direct3D 12 capture.** Both OpenXR graphics bindings are
+  supported through the shared-texture mirror path.
+- **Recording-only overscan.** Compatible applications can render a wider FOV
+  and larger swapchain for OBS while the runtime still receives the original
+  center view, so the headset image remains unchanged.
+- **FOV-boundary effect matching.** An optional live correction estimates a
+  projection-baked fullscreen effect at the native-FOV boundary and extends it
+  into the overscan guard band. The correction affects only the recording.
+- **Recording camera smoothing.** Low-pass pose filtering, crop margin, snap
+  handling, and global Control Center overrides reduce small head movements
+  without changing headset tracking.
+- **Quad-layer visibility.** Include or omit genuine OpenXR composition quad
+  layers from the OBS mirror while leaving headset composition untouched.
+- **Safer live updates.** Hash-versioned layer binaries avoid overwriting a DLL
+  already loaded by an OpenXR session, and status hashes show when either native
+  component needs an update.
+- **More reliable lifecycle handling.** GPU synchronization, swapchain teardown,
+  and adapter diagnostics have been hardened. A shared-surface generation ID
+  now makes the OBS source reconnect automatically when an application session
+  or mirror texture ring is replaced, even if Windows reuses a handle value.
+
+## Install
+
+1. Close OBS Studio and any running OpenXR application.
+2. Download and run `OpenXR-OBSMirror-0.3.0-beta.1-Setup.exe`.
+3. Open OBS Studio and add an **OpenXR Mirror Capture** source.
+4. Start the OpenXR application normally through your headset software.
+
+The portable ZIP contains the same self-contained app and payload. Extract the
+whole archive, launch `Launch OpenXR OBS Mirror.cmd`, then use **Install /
+update** on the Installation page.
+
+## Compatibility and notes
+
+- Windows 10 1809 or later, x64.
+- OBS Studio 32.2.1 for the included OBS source binary.
+- OpenXR applications using Direct3D 11 or Direct3D 12.
+- Overscan depends on the application honoring the FOV and recommended image
+  size returned by `xrLocateViews` and `xrEnumerateViewConfigurationViews`.
+- Fullscreen-effect matching is a compatibility tool; leave it disabled unless
+  the added perimeter exposes an effect boundary.
+- The installer is currently unsigned. Windows may show an
+  unrecognized-publisher warning; SHA-256 hashes are included with the release.
+
+See `docs/INSTALL.md` in either download for complete setup, updating,
+uninstalling, and troubleshooting instructions.

--- a/installer/OpenXR-OBSMirror.iss
+++ b/installer/OpenXR-OBSMirror.iss
@@ -1,0 +1,66 @@
+#ifndef MyAppVersion
+  #define MyAppVersion "0.3.0-beta.1"
+#endif
+#ifndef MyFileVersion
+  #define MyFileVersion "0.3.0.1"
+#endif
+#ifndef PayloadRoot
+  #define PayloadRoot "..\artifacts\payload"
+#endif
+#ifndef OutputDirectory
+  #define OutputDirectory "..\artifacts"
+#endif
+
+[Setup]
+AppId={{8B49FA68-2786-4DCB-9A42-AC20AEF8208C}
+AppName=OpenXR OBS Mirror
+AppVersion={#MyAppVersion}
+AppVerName=OpenXR OBS Mirror {#MyAppVersion}
+AppPublisher=Elliott Tate
+AppPublisherURL=https://github.com/elliotttate/OpenXR-Layer-OBSMirror
+AppSupportURL=https://github.com/elliotttate/OpenXR-Layer-OBSMirror/issues
+AppUpdatesURL=https://github.com/elliotttate/OpenXR-Layer-OBSMirror/releases
+DefaultDirName={autopf}\OpenXR OBS Mirror
+DefaultGroupName=OpenXR OBS Mirror
+DisableProgramGroupPage=yes
+LicenseFile=..\LICENSE
+InfoBeforeFile=..\docs\INSTALL.md
+OutputDir={#OutputDirectory}
+OutputBaseFilename=OpenXR-OBSMirror-{#MyAppVersion}-Setup
+SetupIconFile=..\ControlCenter\Assets\OBSMirror.ControlCenter.ico
+UninstallDisplayIcon={app}\ControlCenter\OBSMirror.ControlCenter.exe
+Compression=lzma2/ultra64
+SolidCompression=yes
+WizardStyle=modern
+PrivilegesRequired=admin
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+CloseApplications=yes
+RestartApplications=no
+VersionInfoVersion={#MyFileVersion}
+VersionInfoTextVersion={#MyAppVersion}
+VersionInfoCompany=Elliott Tate
+VersionInfoDescription=OpenXR OBS Mirror Setup
+VersionInfoProductName=OpenXR OBS Mirror
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
+
+[Files]
+Source: "{#PayloadRoot}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#PayloadRoot}\bin\x64\Release\OBS_Plugin\win-openxr.dll"; DestDir: "{commonappdata}\obs-studio\plugins\win-openxr\bin\64bit"; Flags: ignoreversion restartreplace
+Source: "{#PayloadRoot}\OBSPlugin\win-openxr\data\*"; DestDir: "{commonappdata}\obs-studio\plugins\win-openxr\data"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\OpenXR OBS Mirror"; Filename: "{app}\ControlCenter\OBSMirror.ControlCenter.exe"; WorkingDir: "{app}"
+Name: "{autodesktop}\OpenXR OBS Mirror"; Filename: "{app}\ControlCenter\OBSMirror.ControlCenter.exe"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Run]
+Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\Setup-OBS.ps1"" -AllowRunningOBS -SkipPluginInstall"; StatusMsg: "Registering the OpenXR mirror layer..."; Flags: runhidden waituntilterminated runasoriginaluser
+Filename: "{app}\ControlCenter\OBSMirror.ControlCenter.exe"; Description: "Open Control Center"; WorkingDir: "{app}"; Flags: nowait postinstall skipifsilent runasoriginaluser
+
+[UninstallRun]
+Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\Uninstall-OBSMirror.ps1"""; Flags: runhidden waituntilterminated; RunOnceId: "UnregisterOpenXRLayer"

--- a/scripts/Build-ControlCenter.ps1
+++ b/scripts/Build-ControlCenter.ps1
@@ -1,7 +1,9 @@
 [CmdletBinding()]
 param(
     [ValidateSet('Debug', 'Release')]
-    [string]$Configuration = 'Release'
+    [string]$Configuration = 'Release',
+
+    [string]$OutputDirectory
 )
 
 Set-StrictMode -Version Latest
@@ -9,7 +11,10 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $project = Join-Path $repoRoot 'ControlCenter\OBSMirror.ControlCenter.csproj'
-$output = Join-Path $repoRoot "bin\x64\$Configuration\ControlCenter"
+if (-not $OutputDirectory) {
+    $OutputDirectory = Join-Path $repoRoot "bin\x64\$Configuration\ControlCenter"
+}
+$output = [IO.Path]::GetFullPath($OutputDirectory)
 
 & dotnet publish $project -c $Configuration -p:Platform=x64 -r win-x64 `
     --self-contained true -o $output `

--- a/scripts/Build-Release.ps1
+++ b/scripts/Build-Release.ps1
@@ -1,0 +1,141 @@
+[CmdletBinding()]
+param(
+    [string]$Version = '0.3.0-beta.1',
+    [string]$FileVersion = '0.3.0.1',
+    [string]$OBSSourcePath = 'E:\Github\obs-studio',
+    [string]$OBSInstallPath = 'C:\Program Files\obs-studio'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ($Version -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
+    throw "Version must look like 0.3.0 or 0.3.0-beta.1: $Version"
+}
+if ($FileVersion -notmatch '^\d+\.\d+\.\d+\.\d+$') {
+    throw "FileVersion must contain four numeric components: $FileVersion"
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$tag = "v$Version"
+$artifactsRoot = Join-Path $repoRoot 'artifacts'
+$releaseDirectory = Join-Path $artifactsRoot $tag
+$stageDirectory = Join-Path $artifactsRoot ".stage-$tag"
+$payloadRoot = Join-Path $stageDirectory 'OpenXR OBS Mirror'
+
+foreach ($target in @($releaseDirectory, $stageDirectory)) {
+    $fullTarget = [IO.Path]::GetFullPath($target)
+    $fullArtifactsRoot = [IO.Path]::GetFullPath($artifactsRoot).TrimEnd('\') + '\'
+    if (-not $fullTarget.StartsWith($fullArtifactsRoot, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to clean a path outside the repository artifacts directory: $fullTarget"
+    }
+    if (Test-Path -LiteralPath $fullTarget) {
+        Remove-Item -LiteralPath $fullTarget -Recurse -Force
+    }
+}
+New-Item -ItemType Directory -Path $releaseDirectory, $payloadRoot -Force | Out-Null
+
+$vswhere = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
+if (-not (Test-Path -LiteralPath $vswhere -PathType Leaf)) {
+    throw "Visual Studio locator not found: $vswhere"
+}
+$msbuild = & $vswhere -latest -version '[17.0,18.0)' -products * `
+    -requires Microsoft.Component.MSBuild -find 'MSBuild\**\Bin\MSBuild.exe' |
+    Select-Object -First 1
+if (-not $msbuild) { throw 'Visual Studio 2022 MSBuild was not found.' }
+
+& $msbuild (Join-Path $repoRoot 'OpenXR-Layer-OBSMirror.sln') /m `
+    /t:Build /p:Configuration=Release /p:Platform=x64
+if ($LASTEXITCODE -ne 0) { throw "Native layer build failed (exit $LASTEXITCODE)." }
+
+& (Join-Path $PSScriptRoot 'Build-OBSPlugin.ps1') `
+    -OBSSourcePath $OBSSourcePath -OBSInstallPath $OBSInstallPath -Configuration Release
+if ($LASTEXITCODE -ne 0) { throw "OBS plugin build failed (exit $LASTEXITCODE)." }
+
+$controlCenterOutput = Join-Path $payloadRoot 'ControlCenter'
+& (Join-Path $PSScriptRoot 'Build-ControlCenter.ps1') `
+    -Configuration Release -OutputDirectory $controlCenterOutput
+if ($LASTEXITCODE -ne 0) { throw "Control Center build failed (exit $LASTEXITCODE)." }
+
+$payloadDirectories = @(
+    (Join-Path $payloadRoot 'bin\x64\Release\OBS_Plugin'),
+    (Join-Path $payloadRoot 'scripts'),
+    (Join-Path $payloadRoot 'OBSPlugin\win-openxr\data'),
+    (Join-Path $payloadRoot 'docs\release-notes')
+)
+New-Item -ItemType Directory -Path $payloadDirectories -Force | Out-Null
+
+$releaseBin = Join-Path $repoRoot 'bin\x64\Release'
+foreach ($fileName in @(
+    'XR_APILAYER_NOVENDOR_OBSMirror.dll',
+    'XR_APILAYER_NOVENDOR_OBSMirror.json'
+)) {
+    Copy-Item -LiteralPath (Join-Path $releaseBin $fileName) `
+        -Destination (Join-Path $payloadRoot 'bin\x64\Release') -Force
+}
+Copy-Item -LiteralPath (Join-Path $releaseBin 'OBS_Plugin\win-openxr.dll') `
+    -Destination (Join-Path $payloadRoot 'bin\x64\Release\OBS_Plugin') -Force
+
+foreach ($scriptName in @(
+    'Setup-OBS.ps1',
+    'Install-Layer.ps1',
+    'Uninstall-Layer.ps1',
+    'Uninstall-OBSMirror.ps1',
+    'Set-RecordingOverscan.ps1'
+)) {
+    Copy-Item -LiteralPath (Join-Path $PSScriptRoot $scriptName) `
+        -Destination (Join-Path $payloadRoot 'scripts') -Force
+}
+Copy-Item -Path (Join-Path $repoRoot 'OBSPlugin\win-openxr\data\*') `
+    -Destination (Join-Path $payloadRoot 'OBSPlugin\win-openxr\data') -Recurse -Force
+
+foreach ($fileName in @('README.md', 'LICENSE', 'THIRD_PARTY', 'Launch OpenXR OBS Mirror.cmd')) {
+    Copy-Item -LiteralPath (Join-Path $repoRoot $fileName) -Destination $payloadRoot -Force
+}
+Copy-Item -LiteralPath (Join-Path $repoRoot 'docs\INSTALL.md') `
+    -Destination (Join-Path $payloadRoot 'docs') -Force
+Copy-Item -LiteralPath (Join-Path $repoRoot "docs\release-notes\$tag.md") `
+    -Destination (Join-Path $payloadRoot 'docs\release-notes') -Force
+
+$metadata = [ordered]@{
+    product = 'OpenXR OBS Mirror'
+    version = $Version
+    tag = $tag
+    platform = 'Windows x64'
+    obs_version = (Get-Item -LiteralPath (Join-Path $OBSInstallPath 'bin\64bit\obs64.exe')).VersionInfo.ProductVersion
+    graphics_apis = @('Direct3D 11', 'Direct3D 12')
+}
+$metadata | ConvertTo-Json -Depth 4 | Set-Content `
+    -LiteralPath (Join-Path $payloadRoot 'release.json') -Encoding utf8
+
+$iscc = 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
+if (-not (Test-Path -LiteralPath $iscc -PathType Leaf)) {
+    throw "Inno Setup 6 compiler not found: $iscc"
+}
+& $iscc '/Qp' "/DMyAppVersion=$Version" "/DMyFileVersion=$FileVersion" `
+    "/DPayloadRoot=$payloadRoot" "/DOutputDirectory=$releaseDirectory" `
+    (Join-Path $repoRoot 'installer\OpenXR-OBSMirror.iss')
+if ($LASTEXITCODE -ne 0) { throw "Installer build failed (exit $LASTEXITCODE)." }
+
+$zipPath = Join-Path $releaseDirectory "OpenXR-OBSMirror-$Version-Portable.zip"
+Compress-Archive -LiteralPath $payloadRoot -DestinationPath $zipPath -CompressionLevel Optimal
+
+$releaseFiles = Get-ChildItem -LiteralPath $releaseDirectory -File |
+    Where-Object { $_.Name -ne 'SHA256SUMS.txt' } |
+    Sort-Object Name
+$checksumLines = foreach ($file in $releaseFiles) {
+    $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $file.FullName).Hash.ToLowerInvariant()
+    "$hash *$($file.Name)"
+}
+$checksumPath = Join-Path $releaseDirectory 'SHA256SUMS.txt'
+$checksumLines | Set-Content -LiteralPath $checksumPath -Encoding ascii
+
+Remove-Item -LiteralPath $stageDirectory -Recurse -Force
+
+[pscustomobject]@{
+    Version = $Version
+    Directory = $releaseDirectory
+    Installer = Join-Path $releaseDirectory "OpenXR-OBSMirror-$Version-Setup.exe"
+    Portable = $zipPath
+    Checksums = $checksumPath
+}

--- a/scripts/Set-RecordingOverscan.ps1
+++ b/scripts/Set-RecordingOverscan.ps1
@@ -31,7 +31,12 @@ if ($Disable) {
 }
 
 if ($PSCmdlet.ShouldProcess($registryPath, "Enable recording overscan ${HorizontalPercent}% x ${VerticalPercent}%")) {
-    New-Item -Path $registryPath -Force | Out-Null
+    # Do not recreate an existing key with -Force: the Registry provider can
+    # clear sibling values owned by the Control Center (camera smoothing,
+    # quad-layer visibility, and guard-band matching).
+    if (-not (Test-Path -LiteralPath $registryPath)) {
+        New-Item -Path $registryPath | Out-Null
+    }
     Set-ItemProperty -LiteralPath $registryPath -Name 'RecordingOverscan' -Value 1 -Type DWord
     Set-ItemProperty -LiteralPath $registryPath -Name 'OverscanHorizontalPercent' -Value $HorizontalPercent -Type DWord
     Set-ItemProperty -LiteralPath $registryPath -Name 'OverscanVerticalPercent' -Value $VerticalPercent -Type DWord

--- a/scripts/Setup-OBS.ps1
+++ b/scripts/Setup-OBS.ps1
@@ -4,7 +4,8 @@ param(
     [string]$PluginBinary,
     [string]$LayerInstallDirectory = (Join-Path $env:LOCALAPPDATA 'OpenXR-OBSMirror'),
     [string]$OBSPluginDirectory = (Join-Path $env:ProgramData 'obs-studio\plugins\win-openxr'),
-    [switch]$AllowRunningOBS
+    [switch]$AllowRunningOBS,
+    [switch]$SkipPluginInstall
 )
 
 Set-StrictMode -Version Latest
@@ -24,7 +25,9 @@ if ($runningOBS -and -not $AllowRunningOBS) {
 }
 $layerDll = Join-Path $LayerBuildDirectory 'XR_APILAYER_NOVENDOR_OBSMirror.dll'
 $layerManifest = Join-Path $LayerBuildDirectory 'XR_APILAYER_NOVENDOR_OBSMirror.json'
-foreach ($requiredPath in @($layerDll, $layerManifest, $PluginBinary)) {
+$requiredPaths = @($layerDll, $layerManifest)
+if (-not $SkipPluginInstall) { $requiredPaths += $PluginBinary }
+foreach ($requiredPath in $requiredPaths) {
     if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
         throw "Required build artifact not found: $requiredPath"
     }
@@ -34,8 +37,10 @@ $layerInstall = [IO.Path]::GetFullPath($LayerInstallDirectory)
 $pluginInstall = [IO.Path]::GetFullPath($OBSPluginDirectory)
 $pluginBinDirectory = Join-Path $pluginInstall 'bin\64bit'
 $pluginDataDirectory = Join-Path $pluginInstall 'data'
-New-Item -ItemType Directory -Path $layerInstall, $pluginBinDirectory, $pluginDataDirectory -Force |
-    Out-Null
+New-Item -ItemType Directory -Path $layerInstall -Force | Out-Null
+if (-not $SkipPluginInstall) {
+    New-Item -ItemType Directory -Path $pluginBinDirectory, $pluginDataDirectory -Force | Out-Null
+}
 
 $layerSourceHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $layerDll).Hash
 $versionedLayerName = "XR_APILAYER_NOVENDOR_OBSMirror.$($layerSourceHash.Substring(0, 12).ToLowerInvariant()).dll"
@@ -55,19 +60,20 @@ foreach ($scriptName in @('Install-Layer.ps1', 'Uninstall-Layer.ps1')) {
 }
 
 $pluginDestination = Join-Path $pluginBinDirectory 'win-openxr.dll'
-$pluginSourceHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $PluginBinary).Hash
-$pluginAlreadyCurrent = (Test-Path -LiteralPath $pluginDestination -PathType Leaf) -and
-    ((Get-FileHash -Algorithm SHA256 -LiteralPath $pluginDestination).Hash -eq $pluginSourceHash)
-if ($runningOBS -and -not $pluginAlreadyCurrent) {
-    Write-Warning 'OBS is running; the plugin is staged but will not load until OBS restarts.'
+if (-not $SkipPluginInstall) {
+    $pluginSourceHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $PluginBinary).Hash
+    $pluginAlreadyCurrent = (Test-Path -LiteralPath $pluginDestination -PathType Leaf) -and
+        ((Get-FileHash -Algorithm SHA256 -LiteralPath $pluginDestination).Hash -eq $pluginSourceHash)
+    if ($runningOBS -and -not $pluginAlreadyCurrent) {
+        Write-Warning 'OBS is running; close it before installing the updated plugin binary.'
+    } elseif ($pluginAlreadyCurrent) {
+        Write-Verbose "OBS plugin is already current; skipping the in-use DLL copy."
+    } else {
+        Copy-Item -LiteralPath $PluginBinary -Destination $pluginDestination -Force
+    }
+    Copy-Item -Path (Join-Path $repoRoot 'OBSPlugin\win-openxr\data\*') `
+        -Destination $pluginDataDirectory -Recurse -Force
 }
-if ($pluginAlreadyCurrent) {
-    Write-Verbose "OBS plugin is already current; skipping the in-use DLL copy."
-} else {
-    Copy-Item -LiteralPath $PluginBinary -Destination $pluginDestination -Force
-}
-Copy-Item -Path (Join-Path $repoRoot 'OBSPlugin\win-openxr\data\*') `
-    -Destination $pluginDataDirectory -Recurse -Force
 
 & (Join-Path $PSScriptRoot 'Install-Layer.ps1') -Scope CurrentUser `
     -ManifestPath $installedManifest
@@ -76,6 +82,8 @@ Copy-Item -Path (Join-Path $repoRoot 'OBSPlugin\win-openxr\data\*') `
     LayerManifest = $installedManifest
     LayerBinary = $versionedLayerPath
     LayerSHA256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $versionedLayerPath).Hash
-    OBSPlugin = $pluginDestination
-    PluginSHA256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $pluginDestination).Hash
+    OBSPlugin = if (Test-Path -LiteralPath $pluginDestination -PathType Leaf) { $pluginDestination } else { $null }
+    PluginSHA256 = if (Test-Path -LiteralPath $pluginDestination -PathType Leaf) {
+        (Get-FileHash -Algorithm SHA256 -LiteralPath $pluginDestination).Hash
+    } else { $null }
 }

--- a/scripts/Uninstall-OBSMirror.ps1
+++ b/scripts/Uninstall-OBSMirror.ps1
@@ -1,0 +1,20 @@
+[CmdletBinding(SupportsShouldProcess)]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+& (Join-Path $PSScriptRoot 'Uninstall-Layer.ps1') -Scope CurrentUser
+
+$layerDirectory = [IO.Path]::GetFullPath(
+    (Join-Path $env:LOCALAPPDATA 'OpenXR-OBSMirror'))
+$expectedDirectory = [IO.Path]::GetFullPath($env:LOCALAPPDATA).TrimEnd('\') + `
+    '\OpenXR-OBSMirror'
+if (-not $layerDirectory.Equals($expectedDirectory, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "Refusing to remove an unexpected layer directory: $layerDirectory"
+}
+
+if ((Test-Path -LiteralPath $layerDirectory) -and
+    $PSCmdlet.ShouldProcess($layerDirectory, 'Remove installed OpenXR layer files')) {
+    Remove-Item -LiteralPath $layerDirectory -Recurse -Force
+}

--- a/shared/obs_mirror_ipc.h
+++ b/shared/obs_mirror_ipc.h
@@ -29,15 +29,21 @@ namespace obs_mirror_ipc {
         // Tan-space crop percentage the smoother may pan within (0-25).
         float smoothCrop = 8.0f;
         std::uint64_t sharedHandle[kMirrorTextureCount] = {};
+        // Published last whenever the layer replaces the shared texture ring.
+        // Handles can be numerically reused by Windows across application
+        // processes, so OBS must not rely on handle equality alone to detect a
+        // new capture session.
+        std::atomic<std::uint32_t> surfaceGeneration{0};
 
         void reset() {
             for (auto& handle : sharedHandle)
                 handle = 0;
+            surfaceGeneration.fetch_add(1, std::memory_order_release);
         }
     };
 
     static_assert(std::atomic<std::uint32_t>::is_always_lock_free,
                   "Cross-process signalling requires lock-free 32-bit atomics");
-    static_assert(sizeof(MirrorSurfaceData) == 56, "The OpenXR layer and OBS plugin must use the same IPC layout");
+    static_assert(sizeof(MirrorSurfaceData) == 64, "The OpenXR layer and OBS plugin must use the same IPC layout");
 
 } // namespace obs_mirror_ipc


### PR DESCRIPTION
## Summary

- add the self-contained WinUI 3 Control Center distribution, versioned installer, portable package builder, install guide, and formal release notes
- add recording-only fullscreen-effect boundary matching and expose it in Control Center
- package and document recording overscan, camera smoothing, and quad-layer visibility controls
- harden shared-surface lifecycle handling so the OBS source reconnects when the capture texture ring or application session changes
- preserve the machine headset runtime as the normal default and keep simulator selection explicit

## Validation

- Visual Studio 2022 x64 Release native layer build
- OBS Studio 32.2.1 plugin build against matching source
- self-contained WinUI 3 publish and clean portable launch
- Inno Setup 6 installer compile
- portable ZIP structure and SHA-256 manifest verification
- physical-headset OpenXR session through the system SteamVR runtime
- installed layer and OBS plugin hashes match the packaged payload
- PowerShell parse validation and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Package v0.3.0-beta: first full Windows distribution with a self‑contained Control Center, an installer, and a portable ZIP. Adds recording-only FOV overscan tools, fullscreen‑effect boundary matching, and more reliable OBS reconnection.

- **New Features**
  - Self-contained WinUI 3 Control Center distribution with installer (Inno Setup), portable ZIP, and release scripts (`Build-Release.ps1`), plus install and release docs.
  - Recording-only fullscreen‑effect boundary matching at the FOV edge with live strength control; exposed in Control Center; affects only the OBS mirror.
  - Packaged controls for overscan, camera smoothing, and quad‑layer visibility; updated UI and status in Control Center.
  - Hardened shared-surface lifecycle: published generation ID and OBS plugin reconnect on texture-ring/session changes (even if a handle value is reused).
  - Keeps the machine headset runtime as the default; simulator selection stays explicit.
  - Updated layer metadata (`implementation_version: 3`) and README with quick install, D3D11/D3D12 notes, and troubleshooting.

- **Migration**
  - Use the new installer or portable package; then add an OpenXR Mirror Capture source in OBS.
  - Restart the VR app after overscan changes; boundary matching, smoothing, and quad‑layer visibility update live.
  - Restart OBS if the plugin binary was updated.

<sup>Written for commit 8a4f58957b186cf2d9dc506f43aeae405af57dbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elliotttate/OpenXR-Layer-OBSMirror/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

