### PR TITLE
Showcase demo videos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Key recording controls include:
 - independent show/hide control for OpenXR composition quad layers;
 - live runtime, layer, plugin, hash, and diagnostic-log status.
 
+## See it in action
+
+| Wider FOV + smoothed camera | Control Center walkthrough |
+| :---: | :---: |
+| [![Halo Large FOV Smoothed Footage](https://img.youtube.com/vi/0Aa91IXBh3c/maxresdefault.jpg)](https://youtu.be/0Aa91IXBh3c) | [![OBS OpenXR Recording UI](https://img.youtube.com/vi/0CDRNip2I10/maxresdefault.jpg)](https://www.youtube.com/watch?v=0CDRNip2I10) |
+| Recording-only FOV overscan and camera smoothing in action. | A guided tour of installation, status, and recording controls. |
+
+Click either preview to watch on YouTube.
+
 The OpenXR layer template was based on
 [OpenXR-Layer-Template](https://github.com/mbucchia/OpenXR-Layer-Template).
 


### PR DESCRIPTION
## What changed

- adds a prominent two-column **See it in action** section near the top of the README
- embeds clickable YouTube previews for the wider-FOV/camera-smoothing demo and the Control Center walkthrough
- adds concise captions so visitors can quickly choose the relevant video

## Why

The repository page now demonstrates both the recording result and the setup/control experience without requiring visitors to hunt for external links.

## Validation

- `git diff --check`
- confirmed both YouTube videos resolve and both `maxresdefault.jpg` thumbnails return HTTP 200

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “See it in action” section near the top of the README with two clickable YouTube previews (wider FOV + smoothed camera, and Control Center walkthrough). This helps visitors quickly see recording results and the setup/control flow without hunting for links.

<sup>Written for commit 11c16d572808955c7f6440893cc4d1ff2fec337f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elliotttate/OpenXR-Layer-OBSMirror/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

