### PR TITLE
Fix Control Center registration on clean Windows PCs

### DIFF
--- a/ControlCenter/OBSMirror.ControlCenter.csproj
+++ b/ControlCenter/OBSMirror.ControlCenter.csproj
@@ -16,10 +16,10 @@
     <RootNamespace>OBSMirror.ControlCenter</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\OBSMirror.ControlCenter.ico</ApplicationIcon>
-    <Version>0.3.0-beta.1</Version>
-    <AssemblyVersion>0.3.0.1</AssemblyVersion>
-    <FileVersion>0.3.0.1</FileVersion>
-    <InformationalVersion>0.3.0-beta.1</InformationalVersion>
+    <Version>0.3.0-beta.2</Version>
+    <AssemblyVersion>0.3.0.2</AssemblyVersion>
+    <FileVersion>0.3.0.2</FileVersion>
+    <InformationalVersion>0.3.0-beta.2</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ControlCenter/Services/OBSMirrorService.cs
+++ b/ControlCenter/Services/OBSMirrorService.cs
@@ -489,7 +489,7 @@ public sealed class OBSMirrorService
 
     private static async Task<string> RunPowerShellAsync(string scriptPath, IEnumerable<string> scriptArguments)
     {
-        var startInfo = new ProcessStartInfo("pwsh")
+        var startInfo = new ProcessStartInfo(ResolvePowerShellExecutable())
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -515,6 +515,45 @@ public sealed class OBSMirrorService
         if (process.ExitCode != 0)
             throw new InvalidOperationException(string.IsNullOrEmpty(error) ? output : error);
         return string.IsNullOrWhiteSpace(output) ? "Completed successfully." : output;
+    }
+
+    private static string ResolvePowerShellExecutable()
+    {
+        // Windows PowerShell is part of supported Windows installations and is
+        // also the host used by the installer. PowerShell 7 (`pwsh`) is optional
+        // and must not be a prerequisite for Control Center actions.
+        var systemDirectory = Environment.GetFolderPath(Environment.SpecialFolder.System);
+        if (!string.IsNullOrWhiteSpace(systemDirectory))
+        {
+            var windowsPowerShell = Path.Combine(
+                systemDirectory,
+                "WindowsPowerShell",
+                "v1.0",
+                "powershell.exe");
+            if (File.Exists(windowsPowerShell))
+                return windowsPowerShell;
+        }
+
+        var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        if (!string.IsNullOrWhiteSpace(programFiles))
+        {
+            var powerShell7 = Path.Combine(programFiles, "PowerShell", "7", "pwsh.exe");
+            if (File.Exists(powerShell7))
+                return powerShell7;
+        }
+
+        foreach (var directory in (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+                     .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var powerShell7 = Path.Combine(directory.Trim('"'), "pwsh.exe");
+            if (File.Exists(powerShell7))
+                return powerShell7;
+        }
+
+        throw new FileNotFoundException(
+            "Neither Windows PowerShell nor PowerShell 7 could be found. " +
+            "Windows PowerShell is normally available at " +
+            @"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe.");
     }
 
     private static string FindRepoRoot()

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ portable ZIP, and checksums in one reproducible command:
 
 ```powershell
 pwsh -File .\scripts\Build-Release.ps1 `
-  -Version 0.3.0-beta.1 `
+  -Version 0.3.0-beta.2 `
   -OBSSourcePath E:\Github\obs-studio
 ```
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -6,7 +6,7 @@ OBS Studio while preserving the headset's normal runtime, view, and tracking.
 ## Recommended: Windows installer
 
 1. Close OBS Studio and any running OpenXR application.
-2. Run `OpenXR-OBSMirror-0.3.0-beta.1-Setup.exe`.
+2. Run the downloaded `OpenXR-OBSMirror-...-Setup.exe`.
 3. Accept the Windows administrator prompt. It is used only to place the OBS
    source in OBS Studio's shared plugin directory.
 4. Leave **Open Control Center** selected and finish setup.
@@ -28,8 +28,9 @@ runtime. If Control Center reports an inherited simulator override, use
 5. Restart OBS Studio and add an **OpenXR Mirror Capture** source.
 
 The portable Control Center is self-contained; a separate .NET installation is
-not required. Keep the extracted folder intact because it contains the native
-layer, OBS source, scripts, and app runtime.
+not required, and its installation actions use Windows PowerShell included
+with Windows (PowerShell 7 is optional). Keep the extracted folder intact
+because it contains the native layer, OBS source, scripts, and app runtime.
 
 ## Recording controls
 

--- a/docs/release-notes/v0.3.0-beta.2.md
+++ b/docs/release-notes/v0.3.0-beta.2.md
@@ -1,0 +1,29 @@
+# OpenXR OBS Mirror v0.3.0 Beta 2
+
+Beta 2 is a compatibility hotfix for installing and managing the OpenXR layer
+from Control Center on clean Windows PCs.
+
+## Fixed
+
+- **PowerShell 7 is no longer required.** Control Center now uses the built-in
+  Windows PowerShell host used by the installer, then falls back to PowerShell
+  7 only when necessary.
+- **Register, unregister, and install/update work on a stock Windows setup.**
+  These actions no longer fail with `The system cannot find the file specified`
+  when `pwsh` is absent from `PATH`.
+- **Missing-host errors are actionable.** If neither supported PowerShell host
+  can be found, Control Center reports the expected Windows path instead of a
+  generic process-launch failure.
+
+All recording features and native layer binaries remain compatible with Beta
+1. Installing Beta 2 over Beta 1 updates Control Center in place.
+
+## Install or update
+
+1. Close OBS Studio and any running OpenXR application.
+2. Download and run `OpenXR-OBSMirror-0.3.0-beta.2-Setup.exe`.
+3. Open Control Center and confirm that **Layer**, **OBS source**, and
+   **Runtime** are green.
+
+The portable ZIP contains the same self-contained app and payload. Extract the
+complete archive before launching it.

--- a/installer/OpenXR-OBSMirror.iss
+++ b/installer/OpenXR-OBSMirror.iss
@@ -1,8 +1,8 @@
 #ifndef MyAppVersion
-  #define MyAppVersion "0.3.0-beta.1"
+  #define MyAppVersion "0.3.0-beta.2"
 #endif
 #ifndef MyFileVersion
-  #define MyFileVersion "0.3.0.1"
+  #define MyFileVersion "0.3.0.2"
 #endif
 #ifndef PayloadRoot
   #define PayloadRoot "..\artifacts\payload"

--- a/scripts/Build-Release.ps1
+++ b/scripts/Build-Release.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
-    [string]$Version = '0.3.0-beta.1',
-    [string]$FileVersion = '0.3.0.1',
+    [string]$Version = '0.3.0-beta.2',
+    [string]$FileVersion = '0.3.0.2',
     [string]$OBSSourcePath = 'E:\Github\obs-studio',
     [string]$OBSInstallPath = 'C:\Program Files\obs-studio'
 )
@@ -10,7 +10,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 if ($Version -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
-    throw "Version must look like 0.3.0 or 0.3.0-beta.1: $Version"
+    throw "Version must look like 0.3.0 or 0.3.0-beta.2: $Version"
 }
 if ($FileVersion -notmatch '^\d+\.\d+\.\d+\.\d+$') {
     throw "FileVersion must contain four numeric components: $FileVersion"


### PR DESCRIPTION
## What changed

- replaces the Control Center's hardcoded `pwsh` launch with an explicit Windows PowerShell resolver
- uses the built-in Windows PowerShell host first and falls back to PowerShell 7 when available
- reports an actionable error if neither host exists
- bumps the packaged app and installer to `0.3.0-beta.2`
- adds Beta 2 release notes and clarifies that PowerShell 7 is optional

## Root cause

The installer invokes `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, but Control Center invoked the optional PowerShell 7 executable by the bare name `pwsh`. On a clean Windows PC without PowerShell 7 installed, **Register**, **Unregister**, and **Install / update** therefore failed before the script could start.

## User impact

Control Center installation actions now work on a stock supported Windows installation without an additional PowerShell download. Existing Beta 1 installations can be updated in place with the Beta 2 installer.

## Validation

- Release x64 Control Center build: 0 warnings, 0 errors
- full native layer, OBS source, Control Center, installer, portable ZIP, and checksum release pipeline completed
- every shipped PowerShell script parsed under Windows PowerShell 5.1
- registration script completed a no-write `-WhatIf` smoke test under Windows PowerShell 5.1
- packaged Control Center resolver selected `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`
- packaged registration script completed the same no-write smoke test
- portable ZIP metadata and app version verified as `0.3.0-beta.2` / `0.3.0.2`
- installer numeric file version verified as `0.3.0.2`
- all generated SHA-256 checksums verified

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Control Center registration, unregistration, and install/update on clean Windows PCs by launching Windows PowerShell first and falling back to PowerShell 7 when available. Updates version to 0.3.0-beta.2 and clarifies in docs that PowerShell 7 is optional.

- **Bug Fixes**
  - Resolve the PowerShell host at runtime: prefer built-in Windows PowerShell (`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`), then try `pwsh.exe`.
  - Show a clear, actionable error if no supported PowerShell host is found.

<sup>Written for commit c81636d4426d459553d31e1c6c2ec3439fa1c327. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elliotttate/OpenXR-Layer-OBSMirror/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

