### PR TITLE
Replace layer registration actions with a toggle

### DIFF
--- a/ControlCenter/MainWindow.xaml
+++ b/ControlCenter/MainWindow.xaml
@@ -179,9 +179,20 @@
                                                 <RowDefinition Height="Auto" />
                                                 <RowDefinition Height="Auto" />
                                             </Grid.RowDefinitions>
-                                            <Button Grid.Row="0" Grid.Column="0" Click="RegisterLayer_Click" Style="{StaticResource PrimaryButtonStyle}" HorizontalAlignment="Stretch">
-                                                <StackPanel Orientation="Horizontal" Spacing="8"><SymbolIcon Symbol="Link" /><TextBlock Text="Register layer now" /></StackPanel>
-                                            </Button>
+                                            <Border Grid.Row="0" Grid.Column="0" Padding="12,7" CornerRadius="8"
+                                                    BorderBrush="{StaticResource CardStrokeBrush}" BorderThickness="1">
+                                                <Grid ColumnSpacing="10">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Text="Layer" FontWeight="SemiBold" VerticalAlignment="Center" />
+                                                    <ToggleSwitch x:Name="DashboardLayerRegistrationToggle" Grid.Column="1"
+                                                                  HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                                  OnContent="Enabled" OffContent="Disabled"
+                                                                  Toggled="LayerRegistrationToggle_Toggled" />
+                                                </Grid>
+                                            </Border>
                                             <Button Grid.Row="0" Grid.Column="1" Click="LaunchObs_Click" Style="{StaticResource SecondaryButtonStyle}" HorizontalAlignment="Stretch">
                                                 <StackPanel Orientation="Horizontal" Spacing="8"><SymbolIcon Symbol="Video" /><TextBlock Text="Open OBS" /></StackPanel>
                                             </Button>
@@ -485,7 +496,21 @@
                                         <TextBlock Text="OPENXR API LAYER" Style="{StaticResource EyebrowStyle}" />
                                         <TextBlock x:Name="InstallLayerStatusText" FontSize="22" FontWeight="SemiBold" Text="Checking…" />
                                         <TextBlock x:Name="InstallLayerPathText" Style="{StaticResource MutedTextStyle}" FontFamily="Cascadia Mono" FontSize="12" TextWrapping="Wrap" />
-                                        <Button Click="RegisterLayer_Click" Style="{StaticResource SecondaryButtonStyle}" HorizontalAlignment="Left" Content="Register layer now" />
+                                        <Grid ColumnSpacing="20">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                            <StackPanel Spacing="3" VerticalAlignment="Center">
+                                                <TextBlock Text="Enable for the current user" FontWeight="SemiBold" />
+                                                <TextBlock Text="Turn this off to stop OpenXR applications from loading the layer. Installed files and the OBS source remain in place."
+                                                           Style="{StaticResource MutedTextStyle}" TextWrapping="Wrap" />
+                                            </StackPanel>
+                                            <ToggleSwitch x:Name="InstallationLayerRegistrationToggle" Grid.Column="1"
+                                                          HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                          OnContent="Enabled" OffContent="Disabled"
+                                                          Toggled="LayerRegistrationToggle_Toggled" />
+                                        </Grid>
                                     </StackPanel>
                                 </Border>
                                 <Border Grid.Column="1" Style="{StaticResource CardStyle}">
@@ -536,17 +561,6 @@
                                 </Border>
                             </Expander>
 
-                            <Expander Header="Advanced actions">
-                                <Border Style="{StaticResource CardStyle}" Margin="0,8,0,0">
-                                    <Grid>
-                                        <StackPanel>
-                                            <TextBlock Text="Unregister for the current user" FontWeight="SemiBold" />
-                                            <TextBlock Text="Leaves installed files in place and removes only the OpenXR implicit-layer registry entry." Style="{StaticResource MutedTextStyle}" />
-                                        </StackPanel>
-                                        <Button HorizontalAlignment="Right" VerticalAlignment="Center" Click="UnregisterLayer_Click" Content="Unregister layer" />
-                                    </Grid>
-                                </Border>
-                            </Expander>
                         </StackPanel>
                     </ScrollViewer>
 

--- a/ControlCenter/MainWindow.xaml.cs
+++ b/ControlCenter/MainWindow.xaml.cs
@@ -18,6 +18,7 @@ public sealed partial class MainWindow : Window
     private bool _loadingControls;
     private bool _loadingSmoothingControls;
     private bool _loadingQuadLayerControls;
+    private bool _loadingLayerRegistrationControls;
 
     public MainWindow()
     {
@@ -124,7 +125,7 @@ public sealed partial class MainWindow : Window
     {
         SetStatus(LayerDot, LayerStatusText,
             snapshot.LayerRegistered && snapshot.LayerFilesInstalled && snapshot.LayerCurrent,
-            !snapshot.LayerRegistered ? "Not registered" : snapshot.LayerCurrent ? "Registered" : "Update ready");
+            !snapshot.LayerRegistered ? "Disabled" : snapshot.LayerCurrent ? "Enabled" : "Update ready");
         LayerDetailText.Text = snapshot.LayerFilesInstalled
             ? snapshot.LayerCurrent ? $"Installed • {ShortHash(snapshot.LayerHash)}" : "New layer build is ready"
             : "Release files are not installed";
@@ -173,6 +174,8 @@ public sealed partial class MainWindow : Window
         MetaProcessText.Text = snapshot.MetaXrRunning ? "RUNNING" : "IDLE";
         MetaProcessText.Foreground = GetBrush(snapshot.MetaXrRunning ? "GoodBrush" : "MutedTextBrush");
         LaunchMetaButton.IsEnabled = !string.IsNullOrWhiteSpace(snapshot.MetaXrExecutable);
+
+        RenderLayerRegistrationControls(snapshot);
 
         _loadingControls = true;
         OverscanToggle.IsOn = snapshot.OverscanEnabled;
@@ -234,7 +237,7 @@ public sealed partial class MainWindow : Window
         }
 
         InstallLayerStatusText.Text = snapshot.LayerFilesInstalled
-            ? !snapshot.LayerRegistered ? "Installed, registration missing" : snapshot.LayerCurrent ? "Installed and current" : "Installed, update available"
+            ? !snapshot.LayerRegistered ? "Installed, disabled" : snapshot.LayerCurrent ? "Installed and enabled" : "Installed, update available"
             : "Not installed";
         InstallLayerPathText.Text = snapshot.LayerManifestPath;
         InstallPluginStatusText.Text = snapshot.PluginInstalled
@@ -484,34 +487,53 @@ public sealed partial class MainWindow : Window
         });
     }
 
-    private async void RegisterLayer_Click(object sender, RoutedEventArgs e)
+    private async void LayerRegistrationToggle_Toggled(object sender, RoutedEventArgs e)
     {
-        await RunActionAsync("Registering the OpenXR layer", async () =>
-        {
-            var output = await _service.RegisterLayerAsync();
-            ShowMessage("Layer registered", LastLine(output), InfoBarSeverity.Success);
-        });
-    }
-
-    private async void UnregisterLayer_Click(object sender, RoutedEventArgs e)
-    {
-        var dialog = new ContentDialog
-        {
-            XamlRoot = AppTitleBar.XamlRoot,
-            Title = "Unregister the OpenXR layer?",
-            Content = "This removes the current-user OpenXR registration. Installed files and the OBS plugin remain in place.",
-            PrimaryButtonText = "Unregister",
-            CloseButtonText = "Cancel",
-            DefaultButton = ContentDialogButton.Close
-        };
-        if (await dialog.ShowAsync() != ContentDialogResult.Primary)
+        if (_loadingLayerRegistrationControls || sender is not ToggleSwitch toggle)
             return;
 
-        await RunActionAsync("Unregistering the OpenXR layer", async () =>
+        var enable = toggle.IsOn;
+        await RunActionAsync(enable ? "Enabling the OpenXR layer" : "Disabling the OpenXR layer", async () =>
         {
-            var output = await _service.UnregisterLayerAsync();
-            ShowMessage("Layer unregistered", LastLine(output), InfoBarSeverity.Success);
+            if (enable)
+            {
+                var output = await _service.RegisterLayerAsync();
+                ShowMessage("OpenXR layer enabled", LastLine(output), InfoBarSeverity.Success);
+            }
+            else
+            {
+                var output = await _service.UnregisterLayerAsync();
+                ShowMessage(
+                    "OpenXR layer disabled",
+                    LastLine(output) + " Installed files and the OBS source were left in place.",
+                    InfoBarSeverity.Success);
+            }
         });
+
+        // RunActionAsync refreshes successful changes. If an action failed,
+        // restore both switches from the last confirmed snapshot.
+        if (_snapshot is not null && _snapshot.LayerRegistered != enable)
+            RenderLayerRegistrationControls(_snapshot);
+    }
+
+    private void RenderLayerRegistrationControls(SystemSnapshot snapshot)
+    {
+        _loadingLayerRegistrationControls = true;
+        try
+        {
+            DashboardLayerRegistrationToggle.IsOn = snapshot.LayerRegistered;
+            InstallationLayerRegistrationToggle.IsOn = snapshot.LayerRegistered;
+
+            // An existing registration can always be disabled. Enabling needs
+            // the installed manifest and layer binary to be present.
+            var canChangeRegistration = snapshot.LayerRegistered || snapshot.LayerFilesInstalled;
+            DashboardLayerRegistrationToggle.IsEnabled = canChangeRegistration;
+            InstallationLayerRegistrationToggle.IsEnabled = canChangeRegistration;
+        }
+        finally
+        {
+            _loadingLayerRegistrationControls = false;
+        }
     }
 
     private void LaunchObs_Click(object sender, RoutedEventArgs e)

--- a/ControlCenter/OBSMirror.ControlCenter.csproj
+++ b/ControlCenter/OBSMirror.ControlCenter.csproj
@@ -16,10 +16,10 @@
     <RootNamespace>OBSMirror.ControlCenter</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\OBSMirror.ControlCenter.ico</ApplicationIcon>
-    <Version>0.3.0-beta.2</Version>
-    <AssemblyVersion>0.3.0.2</AssemblyVersion>
-    <FileVersion>0.3.0.2</FileVersion>
-    <InformationalVersion>0.3.0-beta.2</InformationalVersion>
+    <Version>0.3.0-beta.3</Version>
+    <AssemblyVersion>0.3.0.3</AssemblyVersion>
+    <FileVersion>0.3.0.3</FileVersion>
+    <InformationalVersion>0.3.0-beta.3</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ portable ZIP, and checksums in one reproducible command:
 
 ```powershell
 pwsh -File .\scripts\Build-Release.ps1 `
-  -Version 0.3.0-beta.2 `
+  -Version 0.3.0-beta.3 `
   -OBSSourcePath E:\Github\obs-studio
 ```
 
@@ -148,8 +148,8 @@ overscan boundary matching.
   and 32-bit per-user selectors. Restart any launcher that was already running
   while the old environment override was active.
 - Some simulator versions refresh OpenXR API-layer registration while testing.
-  If the layer status changes after a simulator session, press
-  **Register layer now** before the next OpenXR application launch.
+  If the layer status changes after a simulator session, turn the **Layer**
+  switch back on before the next OpenXR application launch.
 
 ## Recording overscan (experimental)
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -61,6 +61,11 @@ Center, OBS source, current-user OpenXR layer registration, and installed layer
 files. Close OBS Studio and any OpenXR application first so loaded files can be
 removed immediately.
 
+To temporarily disable capture integration without uninstalling anything, turn
+off the **Layer** switch on the dashboard or **Enable for the current user** on
+the Installation page. Turning it back on restores the current-user OpenXR
+registration; both switches always show the same live state.
+
 ## Troubleshooting
 
 - A black OBS source normally means no active OpenXR session has published a

--- a/docs/release-notes/v0.3.0-beta.3.md
+++ b/docs/release-notes/v0.3.0-beta.3.md
@@ -1,0 +1,34 @@
+# OpenXR OBS Mirror v0.3.0 Beta 3
+
+Beta 3 makes OpenXR layer registration a clear, reversible setting instead of
+separate one-way actions.
+
+## Improved
+
+- **Layer registration is now an on/off switch.** Enable or disable the OpenXR
+  layer directly from either the dashboard or Installation page.
+- **Both switches stay synchronized with Windows.** Refreshing Control Center
+  reads the current-user OpenXR registry entry and updates both controls without
+  triggering an action.
+- **Disabling is non-destructive.** Turning the switch off removes only the
+  current-user implicit-layer registration. The installed native files, OBS
+  source, configuration, and recordings remain untouched.
+- **Failures restore the confirmed state.** If Windows cannot register or
+  unregister the layer, the switch returns to the last verified value and the
+  error remains visible.
+- **Status wording is clearer.** Layer cards now consistently use **Enabled**
+  and **Disabled** instead of mixing registration and installation language.
+
+Beta 3 also includes the Beta 2 compatibility fix that allows Control Center
+installation actions to use Windows PowerShell included with Windows; a
+separate PowerShell 7 installation is not required.
+
+## Install or update
+
+1. Close OBS Studio and any running OpenXR application.
+2. Download and run `OpenXR-OBSMirror-0.3.0-beta.3-Setup.exe`.
+3. Open Control Center and use the **Layer** switch to choose whether new
+   OpenXR applications should load the capture layer.
+
+The portable ZIP contains the same self-contained app and payload. Extract the
+complete archive before launching it.

--- a/installer/OpenXR-OBSMirror.iss
+++ b/installer/OpenXR-OBSMirror.iss
@@ -1,8 +1,8 @@
 #ifndef MyAppVersion
-  #define MyAppVersion "0.3.0-beta.2"
+  #define MyAppVersion "0.3.0-beta.3"
 #endif
 #ifndef MyFileVersion
-  #define MyFileVersion "0.3.0.2"
+  #define MyFileVersion "0.3.0.3"
 #endif
 #ifndef PayloadRoot
   #define PayloadRoot "..\artifacts\payload"

--- a/scripts/Build-Release.ps1
+++ b/scripts/Build-Release.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
-    [string]$Version = '0.3.0-beta.2',
-    [string]$FileVersion = '0.3.0.2',
+    [string]$Version = '0.3.0-beta.3',
+    [string]$FileVersion = '0.3.0.3',
     [string]$OBSSourcePath = 'E:\Github\obs-studio',
     [string]$OBSInstallPath = 'C:\Program Files\obs-studio'
 )
@@ -10,7 +10,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 if ($Version -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
-    throw "Version must look like 0.3.0 or 0.3.0-beta.2: $Version"
+    throw "Version must look like 0.3.0 or 0.3.0-beta.3: $Version"
 }
 if ($FileVersion -notmatch '^\d+\.\d+\.\d+\.\d+$') {
     throw "FileVersion must contain four numeric components: $FileVersion"


### PR DESCRIPTION
## What changed

- replaces the dashboard's one-way **Register layer now** action with an **Enabled / Disabled** switch
- replaces the Installation page's register button and advanced unregister action with one explanatory switch
- synchronizes both switches with the current-user OpenXR registry state during every refresh
- allows an existing registration to be disabled even when installed files are missing, while preventing enablement until the manifest and native layer are present
- restores both switches to the last confirmed state if registration or unregistration fails
- updates status wording and documentation to consistently use **Enabled / Disabled**
- prepares the `v0.3.0-beta.3` installer, portable archive, and release notes

## User impact

Users can temporarily disable the OpenXR layer without uninstalling the native layer, OBS source, settings, or recordings. Turning the switch back on restores the current-user registration.

## Validation

- Release x64 WinUI build completed with 0 warnings and 0 errors
- full native layer, OBS source, Control Center, installer, portable ZIP, and checksum pipeline completed
- visually inspected the dashboard and Installation layouts in the compiled app
- launched the packaged app from a fresh portable ZIP extraction
- confirmed the packaged accessibility tree contains both `DashboardLayerRegistrationToggle` and `InstallationLayerRegistrationToggle`
- confirmed the packaged UI no longer contains the legacy unregister button
- verified packaged app and installer numeric versions are `0.3.0.3`
- verified all generated SHA-256 checksums

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace one-way layer registration actions with a single Enabled/Disabled toggle for the OpenXR layer on both the Dashboard and Installation pages. Toggles stay in sync with Windows, support safe disabling, and block enabling until required files exist.

- **New Features**
  - Added a unified layer toggle on Dashboard and Installation; both reflect the live current-user registry state on refresh.
  - Disabling is non-destructive; enabling requires the manifest and native layer to be installed.
  - On failure, toggles revert to the last confirmed state and show the error.
  - Updated status text to “Enabled/Disabled” and removed the legacy unregister button.
  - Prepared v0.3.0-beta.3: version bumps, installer/script updates, docs, and release notes.

<sup>Written for commit 757c36e5c8e0b3a0495fc16e4264ea384b054808. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elliotttate/OpenXR-Layer-OBSMirror/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

