### PR TITLE
Make VR capture switch APIs automatically

### DIFF
--- a/ControlCenter/MainWindow.xaml
+++ b/ControlCenter/MainWindow.xaml
@@ -219,8 +219,8 @@
                                                 <Button Click="RemoveConflictingPlugin_Click" Content="Remove the old copy" />
                                             </InfoBar.ActionButton>
                                         </InfoBar>
-                                        <InfoBar x:Name="NonOpenXrVrInfoBar" IsOpen="False" IsClosable="False" Severity="Warning"
-                                                 Title="The running VR app is not using OpenXR" />
+                                        <InfoBar x:Name="NonOpenXrVrInfoBar" IsOpen="False" IsClosable="False" Severity="Informational"
+                                                 Title="Checking the running VR application" />
                                     </StackPanel>
                                 </Border>
 

--- a/ControlCenter/MainWindow.xaml.cs
+++ b/ControlCenter/MainWindow.xaml.cs
@@ -299,33 +299,52 @@ public sealed partial class MainWindow : Window
                 "reports as current. Removing the old copy leaves the installed source in place.";
         }
 
-        // Only openxr_loader.dll inserts API layers, so a title that reaches the
-        // headset through LibOVR or OpenVR cannot be captured at all. Without
-        // this the dashboard just waits forever and reports nothing wrong.
-        var showNonOpenXrVrWarning = !string.IsNullOrWhiteSpace(snapshot.NonOpenXrVrApp) &&
-                                     _lastPreviewResult?.Connected != true;
-        NonOpenXrVrInfoBar.IsOpen = showNonOpenXrVrWarning;
-        if (showNonOpenXrVrWarning)
+        // The automatic OBS source has a native SteamVR fallback. Other legacy
+        // VR APIs still cannot be intercepted by an OpenXR API layer.
+        var showNonOpenXrVrStatus = !string.IsNullOrWhiteSpace(snapshot.NonOpenXrVrApp) &&
+                                    _lastPreviewResult?.Connected != true;
+        var isOpenVrCapture = snapshot.NonOpenXrVrPath.Equals(
+            "OpenVR/SteamVR", StringComparison.OrdinalIgnoreCase);
+        NonOpenXrVrInfoBar.IsOpen = showNonOpenXrVrStatus;
+        if (showNonOpenXrVrStatus && isOpenVrCapture)
         {
+            NonOpenXrVrInfoBar.Severity = InfoBarSeverity.Success;
+            NonOpenXrVrInfoBar.Title = "SteamVR capture is available";
+            NonOpenXrVrInfoBar.Message =
+                "The automatic OBS source will use SteamVR's native compositor mirror. " +
+                "OpenXR layer controls do not apply to this capture.";
+        }
+        else if (showNonOpenXrVrStatus)
+        {
+            NonOpenXrVrInfoBar.Severity = InfoBarSeverity.Warning;
+            NonOpenXrVrInfoBar.Title = "This VR API is not capturable yet";
             NonOpenXrVrInfoBar.Message =
                 $"{snapshot.NonOpenXrVrApp} is running VR through the {snapshot.NonOpenXrVrPath} path, not OpenXR. " +
-                "The capture layer can only attach to OpenXR applications — switch the VR mod or game to the " +
-                "OpenXR runtime, then start it again.";
+                "Switch the application to OpenXR or OpenVR/SteamVR, then start it again.";
         }
 
         var runtimeConfigured = !snapshot.RuntimeName.Equals("Not configured", StringComparison.OrdinalIgnoreCase);
-        var runtimeOkay = runtimeConfigured && !snapshot.SimulatorRuntimeOverrideActive;
+        var runtimeIsSimulator = snapshot.SimulatorRuntimeOverrideActive ||
+                                 snapshot.RuntimeName.Contains("Simulator", StringComparison.OrdinalIgnoreCase) ||
+                                 snapshot.RuntimePath.Contains("simulator", StringComparison.OrdinalIgnoreCase);
+        var runtimeOkay = runtimeConfigured && !runtimeIsSimulator;
         SetStatus(RuntimeDot, RuntimeStatusText, runtimeOkay,
-            snapshot.SimulatorRuntimeOverrideActive ? "Simulator override" : snapshot.RuntimeName);
-        RuntimeDetailText.Text = snapshot.SimulatorRuntimeOverrideActive
-            ? $"Restore {snapshot.SystemRuntimeName} for a headset"
+            runtimeIsSimulator ? "Simulator selected" : snapshot.RuntimeName);
+        RuntimeDetailText.Text = runtimeIsSimulator
+            ? snapshot.SimulatorRuntimeOverrideActive
+                ? $"Restore {snapshot.SystemRuntimeName} for a headset"
+                : "Select your headset runtime in its desktop software"
             : snapshot.RuntimeSource;
 
-        if (snapshot.SimulatorRuntimeOverrideActive)
+        if (runtimeIsSimulator)
         {
             RuntimeModeInfoBar.Severity = InfoBarSeverity.Warning;
-            RuntimeModeInfoBar.Title = "Simulator override is active";
-            RuntimeModeInfoBar.Message = $"OpenXR applications will bypass the normal headset runtime. Use headset runtime restores {snapshot.SystemRuntimeName} and clears the per-user override.";
+            RuntimeModeInfoBar.Title = snapshot.SimulatorRuntimeOverrideActive
+                ? "Simulator override is active"
+                : "Simulator is the system OpenXR runtime";
+            RuntimeModeInfoBar.Message = snapshot.SimulatorRuntimeOverrideActive
+                ? $"OpenXR applications will bypass the normal headset runtime. Use headset runtime restores {snapshot.SystemRuntimeName} and clears the per-user override."
+                : "The app did not select this runtime. Choose 'Set as active OpenXR runtime' in your headset or SteamVR software before starting an OpenXR application.";
         }
         else if (!runtimeConfigured)
         {
@@ -713,6 +732,18 @@ public sealed partial class MainWindow : Window
 
     private void RenderMirrorPreview(MirrorPreviewResult result)
     {
+        if (result.Frame is null &&
+            _snapshot?.NonOpenXrVrPath.Equals("OpenVR/SteamVR", StringComparison.OrdinalIgnoreCase) == true &&
+            !string.IsNullOrWhiteSpace(_snapshot.NonOpenXrVrApp))
+        {
+            result = new MirrorPreviewResult(
+                null,
+                "SteamVR capture is ready in OBS",
+                "Open OBS to view the running OpenVR/SteamVR application. This in-app preview reads the OpenXR layer only.",
+                false,
+                false);
+        }
+
         _lastPreviewResult = result;
         UpdateVrRestartIndicator();
         PreviewStatusText.Text = result.Status;
@@ -1212,6 +1243,18 @@ public sealed partial class MainWindow : Window
     {
         try
         {
+            var systemRuntimeIsSimulator = _snapshot is not null &&
+                (_snapshot.SystemRuntimeName.Contains("Simulator", StringComparison.OrdinalIgnoreCase) ||
+                 _snapshot.SystemRuntimePath.Contains("simulator", StringComparison.OrdinalIgnoreCase));
+            if (_snapshot?.RuntimeOverrideActive != true && systemRuntimeIsSimulator)
+            {
+                ShowMessage(
+                    "Select a headset runtime first",
+                    "The system runtime itself is currently the simulator, so there is no headset runtime for this button to restore. Open your headset or SteamVR desktop software and choose 'Set as active OpenXR runtime'.",
+                    InfoBarSeverity.Warning);
+                return;
+            }
+
             var systemRuntimeName = _snapshot?.SystemRuntimeName ?? "the system OpenXR runtime";
             var runtimeChanged = _snapshot?.RuntimeOverrideActive == true ||
                                  _snapshot?.SimulatorRuntimeOverrideActive == true;

--- a/ControlCenter/OBSMirror.ControlCenter.csproj
+++ b/ControlCenter/OBSMirror.ControlCenter.csproj
@@ -17,10 +17,10 @@
     <RootNamespace>OBSMirror.ControlCenter</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\OBSMirror.ControlCenter.ico</ApplicationIcon>
-    <Version>0.3.0-beta.12</Version>
-    <AssemblyVersion>0.3.0.12</AssemblyVersion>
-    <FileVersion>0.3.0.12</FileVersion>
-    <InformationalVersion>0.3.0-beta.12</InformationalVersion>
+    <Version>0.3.0-beta.13</Version>
+    <AssemblyVersion>0.3.0.13</AssemblyVersion>
+    <FileVersion>0.3.0.13</FileVersion>
+    <InformationalVersion>0.3.0-beta.13</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ControlCenter/app.manifest
+++ b/ControlCenter/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="0.3.0.12" name="OBSMirror.ControlCenter.app" />
+  <assemblyIdentity version="0.3.0.13" name="OBSMirror.ControlCenter.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/OBSPlugin/win-openxr/data/locale/en-US.ini
+++ b/OBSPlugin/win-openxr/data/locale/en-US.ini
@@ -1,4 +1,4 @@
-OpenXRMirrorCapture="OpenXR Mirror Capture"
+OpenXRMirrorCapture="VR Mirror Capture (Auto: OpenXR / SteamVR)"
 OpenVRMirrorCapture="OpenVR / SteamVR Mirror Capture"
 EyeCapture="Eye capture"
 EyeLeft="Left"

--- a/OBSPlugin/win-openxr/openvr-capture.cpp
+++ b/OBSPlugin/win-openxr/openvr-capture.cpp
@@ -4,6 +4,7 @@
 #include <d3d11.h>
 #include <dxgi.h>
 #include <openvr.h>
+#include <tlhelp32.h>
 #include <winrt/base.h>
 
 #include <algorithm>
@@ -29,6 +30,26 @@ namespace {
     using VrGetErrorDescription = const char*(VR_CALLTYPE*)(vr::EVRInitError);
 
     extern "C" IMAGE_DOS_HEADER __ImageBase;
+
+    bool steamvr_is_running() {
+        HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if (snapshot == INVALID_HANDLE_VALUE)
+            return false;
+
+        PROCESSENTRY32W entry{};
+        entry.dwSize = sizeof(entry);
+        bool found = false;
+        if (Process32FirstW(snapshot, &entry)) {
+            do {
+                if (_wcsicmp(entry.szExeFile, L"vrserver.exe") == 0) {
+                    found = true;
+                    break;
+                }
+            } while (Process32NextW(snapshot, &entry));
+        }
+        CloseHandle(snapshot);
+        return found;
+    }
 
     std::wstring sibling_openvr_dll_path() {
         std::array<wchar_t, 32768> module_path{};
@@ -371,6 +392,19 @@ namespace {
         deinitialize(context);
         context->last_init_attempt = now;
 
+        // VR_Init can launch SteamVR. An automatic fallback must never start
+        // or switch runtimes while a native OpenXR application is in use, so
+        // only attach after SteamVR's server is already running.
+        if (!steamvr_is_running()) {
+            if (context->last_error_log == 0 || now - context->last_error_log >= 30000) {
+                openvr_blog(LOG_INFO,
+                            "[%s] SteamVR is not running; native OpenVR fallback is idle",
+                            obs_source_get_name(context->source));
+                context->last_error_log = now;
+            }
+            return false;
+        }
+
         std::string failure;
         D3D11_TEXTURE2D_DESC first_desc{};
         D3D11_TEXTURE2D_DESC second_desc{};
@@ -479,24 +513,13 @@ namespace {
 
     void update(void* data, obs_data_t* settings) {
         auto* context = static_cast<OpenVrCapture*>(data);
-        const int eye = std::clamp(static_cast<int>(obs_data_get_int(settings, "openvr_eye")), 0, 2);
-        Crop crop{};
-        crop.top = std::clamp(obs_data_get_double(settings, "openvr_crop_top"), 0.0, 100.0);
-        crop.bottom = std::clamp(obs_data_get_double(settings, "openvr_crop_bottom"), 0.0, 100.0);
-        crop.left = std::clamp(obs_data_get_double(settings, "openvr_crop_left"), 0.0, 100.0);
-        crop.right = std::clamp(obs_data_get_double(settings, "openvr_crop_right"), 0.0, 100.0);
-        const bool fill_canvas = obs_data_get_bool(settings, "openvr_fill_canvas");
-        const bool changed = eye != context->eye || fill_canvas != context->fill_canvas ||
-                             crop.top != context->crop.top || crop.bottom != context->crop.bottom ||
-                             crop.left != context->crop.left || crop.right != context->crop.right;
-        context->eye = eye;
-        context->crop = crop;
-        context->fill_canvas = fill_canvas;
-        if (changed && context->initialized) {
-            deinitialize(context);
-            if (context->active)
-                initialize(context, true);
-        }
+        openvr_capture_configure(reinterpret_cast<openvr_capture_handle*>(context),
+                                 static_cast<int>(obs_data_get_int(settings, "openvr_eye")),
+                                 obs_data_get_bool(settings, "openvr_fill_canvas"),
+                                 obs_data_get_double(settings, "openvr_crop_top"),
+                                 obs_data_get_double(settings, "openvr_crop_right"),
+                                 obs_data_get_double(settings, "openvr_crop_bottom"),
+                                 obs_data_get_double(settings, "openvr_crop_left"));
     }
 
     void defaults(obs_data_t* settings) {
@@ -509,42 +532,38 @@ namespace {
     }
 
     void show(void* data) {
-        auto* context = static_cast<OpenVrCapture*>(data);
-        context->active = true;
-        initialize(context, true);
+        openvr_capture_show(reinterpret_cast<openvr_capture_handle*>(data));
     }
 
     void hide(void* data) {
-        auto* context = static_cast<OpenVrCapture*>(data);
-        context->active = false;
-        deinitialize(context);
+        openvr_capture_hide(reinterpret_cast<openvr_capture_handle*>(data));
     }
 
     void* create(obs_data_t* settings, obs_source_t* source) {
-        auto* context = new (std::nothrow) OpenVrCapture{};
+        auto* context = openvr_capture_create(source);
         if (!context)
             return nullptr;
-        context->source = source;
         update(context, settings);
         return context;
     }
 
     void destroy(void* data) {
-        auto* context = static_cast<OpenVrCapture*>(data);
-        deinitialize(context);
-        delete context;
+        openvr_capture_destroy(reinterpret_cast<openvr_capture_handle*>(data));
     }
 
     uint32_t get_width(void* data) {
-        return static_cast<OpenVrCapture*>(data)->output_width;
+        return openvr_capture_width(reinterpret_cast<openvr_capture_handle*>(data));
     }
 
     uint32_t get_height(void* data) {
-        return static_cast<OpenVrCapture*>(data)->output_height;
+        return openvr_capture_height(reinterpret_cast<openvr_capture_handle*>(data));
     }
 
     void render(void* data, gs_effect_t*) {
-        auto* context = static_cast<OpenVrCapture*>(data);
+        openvr_capture_render(reinterpret_cast<openvr_capture_handle*>(data), nullptr);
+    }
+
+    void render_capture(OpenVrCapture* context) {
         if (!context->active && obs_source_active(context->source))
             context->active = true;
         if (!context->initialized) {
@@ -592,7 +611,10 @@ namespace {
     }
 
     void tick(void* data, float) {
-        auto* context = static_cast<OpenVrCapture*>(data);
+        openvr_capture_tick(reinterpret_cast<openvr_capture_handle*>(data), 0.0f);
+    }
+
+    void tick_capture(OpenVrCapture* context) {
         const bool active = obs_source_active(context->source);
         if (!active && context->active) {
             context->active = false;
@@ -647,6 +669,102 @@ namespace {
     }
 
 } // namespace
+
+openvr_capture_handle *openvr_capture_create(obs_source_t *source)
+{
+    auto *context = new (std::nothrow) OpenVrCapture{};
+    if (!context)
+        return nullptr;
+    context->source = source;
+    return reinterpret_cast<openvr_capture_handle *>(context);
+}
+
+void openvr_capture_destroy(openvr_capture_handle *capture)
+{
+    auto *context = reinterpret_cast<OpenVrCapture *>(capture);
+    if (!context)
+        return;
+    deinitialize(context);
+    delete context;
+}
+
+void openvr_capture_configure(openvr_capture_handle *capture, int eye,
+                              bool fill_canvas, double crop_top,
+                              double crop_right, double crop_bottom,
+                              double crop_left)
+{
+    auto *context = reinterpret_cast<OpenVrCapture *>(capture);
+    if (!context)
+        return;
+
+    Crop crop{};
+    crop.top = std::clamp(crop_top, 0.0, 100.0);
+    crop.right = std::clamp(crop_right, 0.0, 100.0);
+    crop.bottom = std::clamp(crop_bottom, 0.0, 100.0);
+    crop.left = std::clamp(crop_left, 0.0, 100.0);
+    eye = std::clamp(eye, 0, 2);
+    const bool changed = eye != context->eye || fill_canvas != context->fill_canvas ||
+                         crop.top != context->crop.top || crop.right != context->crop.right ||
+                         crop.bottom != context->crop.bottom || crop.left != context->crop.left;
+    context->eye = eye;
+    context->crop = crop;
+    context->fill_canvas = fill_canvas;
+    if (changed && context->initialized) {
+        deinitialize(context);
+        if (context->active)
+            initialize(context, true);
+    }
+}
+
+void openvr_capture_show(openvr_capture_handle *capture)
+{
+    auto *context = reinterpret_cast<OpenVrCapture *>(capture);
+    if (!context)
+        return;
+    context->active = true;
+    initialize(context, true);
+}
+
+void openvr_capture_hide(openvr_capture_handle *capture)
+{
+    auto *context = reinterpret_cast<OpenVrCapture *>(capture);
+    if (!context)
+        return;
+    context->active = false;
+    deinitialize(context);
+}
+
+void openvr_capture_tick(openvr_capture_handle *capture, float)
+{
+    auto *context = reinterpret_cast<OpenVrCapture *>(capture);
+    if (context)
+        tick_capture(context);
+}
+
+void openvr_capture_render(openvr_capture_handle *capture, gs_effect_t *)
+{
+    auto *context = reinterpret_cast<OpenVrCapture *>(capture);
+    if (context)
+        render_capture(context);
+}
+
+uint32_t openvr_capture_width(const openvr_capture_handle *capture)
+{
+    const auto *context = reinterpret_cast<const OpenVrCapture *>(capture);
+    return context ? context->output_width : 100;
+}
+
+uint32_t openvr_capture_height(const openvr_capture_handle *capture)
+{
+    const auto *context = reinterpret_cast<const OpenVrCapture *>(capture);
+    return context ? context->output_height : 100;
+}
+
+bool openvr_capture_ready(const openvr_capture_handle *capture)
+{
+    const auto *context = reinterpret_cast<const OpenVrCapture *>(capture);
+    return context && context->initialized && context->obs_texture;
+}
 
 void register_openvr_capture_source() {
     obs_source_info info{};

--- a/OBSPlugin/win-openxr/openvr-capture.h
+++ b/OBSPlugin/win-openxr/openvr-capture.h
@@ -1,4 +1,24 @@
 #pragma once
 
+#include <obs-module.h>
+
+#include <cstdint>
+
+struct openvr_capture_handle;
+
+openvr_capture_handle *openvr_capture_create(obs_source_t *source);
+void openvr_capture_destroy(openvr_capture_handle *capture);
+void openvr_capture_configure(openvr_capture_handle *capture, int eye,
+			      bool fill_canvas, double crop_top,
+			      double crop_right, double crop_bottom,
+			      double crop_left);
+void openvr_capture_show(openvr_capture_handle *capture);
+void openvr_capture_hide(openvr_capture_handle *capture);
+void openvr_capture_tick(openvr_capture_handle *capture, float seconds);
+void openvr_capture_render(openvr_capture_handle *capture, gs_effect_t *effect);
+uint32_t openvr_capture_width(const openvr_capture_handle *capture);
+uint32_t openvr_capture_height(const openvr_capture_handle *capture);
+bool openvr_capture_ready(const openvr_capture_handle *capture);
+
 void register_openvr_capture_source();
 void shutdown_openvr_capture_runtime();

--- a/OBSPlugin/win-openxr/win-openxr.cpp
+++ b/OBSPlugin/win-openxr/win-openxr.cpp
@@ -64,7 +64,7 @@ using obs_mirror_ipc::kMirrorTextureCount;
 
 // Logged at load and published through the shared diagnostics block so the
 // layer log records which plugin build it talked to.
-static const char *const kPluginVersion = "0.3.0-beta.12";
+static const char *const kPluginVersion = "0.3.0-beta.13";
 
 struct win_openxrmirror {
 	obs_source_t *source;
@@ -135,7 +135,41 @@ struct win_openxrmirror {
 	bool initialized;
 	bool active;
 
+	// The legacy source ID remains the scene-compatible automatic source.
+	// Prefer the layer's OpenXR surface, but use SteamVR's compositor mirror
+	// when an active application is running through OpenVR instead.
+	openvr_capture_handle *openvr_fallback = nullptr;
+	bool openvr_fallback_active = false;
+	bool openvr_fallback_reported = false;
+
 };
+
+static void set_openvr_fallback(win_openxrmirror *context, bool enabled)
+{
+	if (!context->openvr_fallback)
+		return;
+
+	if (enabled && !context->openvr_fallback_active) {
+		context->openvr_fallback_active = true;
+		openvr_capture_show(context->openvr_fallback);
+	} else if (!enabled && context->openvr_fallback_active) {
+		if (context->openvr_fallback_reported && context->initialized)
+			info("OpenXR mirror surface connected; switching back from the SteamVR fallback");
+		openvr_capture_hide(context->openvr_fallback);
+		context->openvr_fallback_active = false;
+		context->openvr_fallback_reported = false;
+	}
+}
+
+static void report_openvr_fallback_if_ready(win_openxrmirror *context)
+{
+	if (context->openvr_fallback_active &&
+	    !context->openvr_fallback_reported &&
+	    openvr_capture_ready(context->openvr_fallback)) {
+		info("OpenXR mirror surface is unavailable; capturing the native SteamVR/OpenVR compositor automatically");
+		context->openvr_fallback_reported = true;
+	}
+}
 
 static void publish_smoothing(win_openxrmirror *context)
 {
@@ -668,6 +702,9 @@ static void win_openxrmirror_update(void *data, obs_data_t *settings)
 	context->captureeye = captureeye;
 	context->crop = newCrop;
 	context->fill_canvas = fillCanvas;
+	openvr_capture_configure(context->openvr_fallback, captureeye,
+				 fillCanvas, newCrop.top, newCrop.right,
+				 newCrop.bottom, newCrop.left);
 
 	context->overlap = static_cast<float>(
 		std::clamp(obs_data_get_double(settings, "eyeoverlap"), 0.0, 100.0));
@@ -717,23 +754,33 @@ static void win_openxrmirror_defaults(obs_data_t *settings)
 static uint32_t win_openxrmirror_getwidth(void *data)
 {
 	struct win_openxrmirror *context = (win_openxrmirror *)data;
+	if (!context->initialized &&
+	    openvr_capture_ready(context->openvr_fallback))
+		return openvr_capture_width(context->openvr_fallback);
 	return context->width;
 }
 
 static uint32_t win_openxrmirror_getheight(void *data)
 {
 	struct win_openxrmirror *context = (win_openxrmirror *)data;
+	if (!context->initialized &&
+	    openvr_capture_ready(context->openvr_fallback))
+		return openvr_capture_height(context->openvr_fallback);
 	return context->height;
 }
 
 static void win_openxrmirror_show(void *data)
 {
+	struct win_openxrmirror *context = (win_openxrmirror *)data;
 	win_openxrmirror_init(data,
 		true); // When showing do forced init without delay
+	set_openvr_fallback(context, !context->initialized);
 }
 
 static void win_openxrmirror_hide(void *data)
 {
+	struct win_openxrmirror *context = (win_openxrmirror *)data;
+	set_openvr_fallback(context, false);
 	win_openxrmirror_deinit(data);
 }
 
@@ -744,6 +791,11 @@ static void *win_openxrmirror_create(obs_data_t *settings, obs_source_t *source)
 	if (!context)
 		return nullptr;
 	context->source = source;
+	context->openvr_fallback = openvr_capture_create(source);
+	if (!context->openvr_fallback) {
+		delete context;
+		return nullptr;
+	}
 
 	context->initialized = false;
 
@@ -763,6 +815,9 @@ static void win_openxrmirror_destroy(void *data)
 {
 	struct win_openxrmirror *context = (win_openxrmirror *)data;
 
+	set_openvr_fallback(context, false);
+	openvr_capture_destroy(context->openvr_fallback);
+	context->openvr_fallback = nullptr;
 	win_openxrmirror_deinit(data);
 	delete context;
 }
@@ -797,6 +852,17 @@ static void win_openxrmirror_render(void *data, gs_effect_t *effect)
 		// Active & want to render but not initialized - attempt to init
 		win_openxrmirror_init(data);
 	}
+
+	if (!context->initialized) {
+		set_openvr_fallback(context, context->active);
+		if (context->active) {
+			openvr_capture_render(context->openvr_fallback, effect);
+			report_openvr_fallback_if_ready(context);
+		}
+		return;
+	}
+
+	set_openvr_fallback(context, false);
 
 	if (!context->texture || !context->active ||
 	    context->mirror_textures.size() != kMirrorTextureCount) {
@@ -841,6 +907,15 @@ static void win_openxrmirror_tick(void *data, float seconds)
 
 	context->active = obs_source_active(context->source);
 	refresh_app_smoothing(context);
+	if (!context->active) {
+		set_openvr_fallback(context, false);
+	} else if (!context->initialized) {
+		set_openvr_fallback(context, true);
+		openvr_capture_tick(context->openvr_fallback, seconds);
+		report_openvr_fallback_if_ready(context);
+	} else {
+		set_openvr_fallback(context, false);
+	}
 
 	// Heartbeat: tells the layer the plugin is alive even on frames where
 	// the source itself is not rendered.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ The OpenXR layer template was based on
 1. Open the [latest GitHub release](https://github.com/elliotttate/OpenXR-Layer-OBSMirror/releases/latest).
 2. Close OBS Studio and any running OpenXR application.
 3. Download and run the `OpenXR-OBSMirror-...-Setup.exe` installer.
-4. Open OBS Studio and add the source matching the application:
-   **OpenXR Mirror Capture** or **OpenVR / SteamVR Mirror Capture**.
+4. Open OBS Studio and add **VR Mirror Capture (Auto: OpenXR / SteamVR)**.
+   It selects the correct capture backend automatically.
 5. Start the VR application normally through your headset software.
 
 Setup installs the matching OBS source, registers the layer for the current
@@ -104,20 +104,23 @@ installs the plugin under OBS's Windows discovery path at
 
 ## Choosing a capture source
 
-- **OpenXR Mirror Capture** reads the application's image through this
-  project's OpenXR API layer. Use it for recording-only FOV overscan, camera
-  smoothing, and OpenXR quad-layer controls. Direct3D 11 and Direct3D 12
-  applications are supported.
+- **VR Mirror Capture (Auto: OpenXR / SteamVR)** is the recommended source. It
+  reads an OpenXR application's image through this project's API layer when one
+  is available, then automatically falls back to SteamVR's native compositor
+  mirror for OpenVR applications. Existing scenes saved with the older
+  **OpenXR Mirror Capture** name are upgraded in place because the source ID is
+  unchanged. Direct3D 11 and Direct3D 12 OpenXR applications are supported.
 - **OpenVR / SteamVR Mirror Capture** reads SteamVR's native compositor mirror
-  without injecting a legacy plugin into the application. It offers left,
+  directly and remains available as an explicit advanced source. It offers left,
   right, and side-by-side stereo modes, percentage crop controls, automatic
   recording-canvas fill, and reconnect-on-demand. SteamVR must be running.
 
-The OpenVR source loads the official Valve OpenVR API from the plugin folder
-only when that source is active. If it is unavailable, the OpenXR source still
-loads and works normally. OpenXR overscan, smoothing, and quad-layer controls
+The automatic source loads the official Valve OpenVR API from the plugin folder
+only when SteamVR is already running and no OpenXR mirror is available. It does
+not launch SteamVR or change the active OpenXR runtime. OpenXR overscan,
+smoothing, and quad-layer controls
 cannot modify an already-composited SteamVR mirror, so those controls apply only
-to **OpenXR Mirror Capture**.
+while the automatic source is using its OpenXR backend.
 
 ## Control Center
 

--- a/XR_APILAYER_NOVENDOR_OBSMirror/layer.h
+++ b/XR_APILAYER_NOVENDOR_OBSMirror/layer.h
@@ -27,7 +27,7 @@
 namespace layer_OBSMirror {
 
     const std::string LayerName = "XR_APILAYER_NOVENDOR_OBSMirror";
-    const std::string VersionString = "v0.3.0-beta.12";
+    const std::string VersionString = "v0.3.0-beta.13";
 
     // Singleton accessor.
     OpenXrApi* GetInstance();

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -13,8 +13,8 @@ headset's normal runtime, view, and tracking.
 4. Leave **Open Control Center** selected and finish setup.
 5. Confirm that **Layer**, **OBS source**, and **Runtime** are green in Control
    Center.
-6. Open OBS Studio and add **OpenXR Mirror Capture** for an OpenXR application,
-   or **OpenVR / SteamVR Mirror Capture** for SteamVR/OpenVR capture.
+6. Open OBS Studio and add **VR Mirror Capture (Auto: OpenXR / SteamVR)**.
+   It chooses the correct backend for the running application.
 7. Start the VR application normally through your headset software.
 
 The installer does not select a simulator or replace the system OpenXR
@@ -29,8 +29,7 @@ runtime. If Control Center reports an inherited simulator override, use
 4. Open **Installation** and choose **Install / update**.
    If the OBS plugin needs to be installed or replaced, approve the Windows
    administrator prompt. Layer-only updates remain per-user and do not elevate.
-5. Restart OBS Studio and add **OpenXR Mirror Capture** or
-   **OpenVR / SteamVR Mirror Capture**, as appropriate.
+5. Restart OBS Studio and add **VR Mirror Capture (Auto: OpenXR / SteamVR)**.
 
 The portable Control Center is self-contained; a separate .NET installation is
 not required. Its installation actions run in the app itself and do not require
@@ -51,17 +50,19 @@ layer, OBS source, scripts, and app runtime.
   Center without requiring OBS to be open.
 
 These recording-only controls belong to the OpenXR layer and therefore apply
-only to **OpenXR Mirror Capture**. The OpenVR source receives an already
+only while the automatic source is using OpenXR. Its OpenVR backend receives an already
 composited SteamVR image; its source properties instead provide eye selection,
 percentage crops, automatic recording-canvas fill, and a reconnect button.
 
 ## OpenVR / SteamVR capture
 
-Start SteamVR, then make the OBS source visible. The source initializes OpenVR
+Start SteamVR, then make the automatic OBS source visible. When no OpenXR layer
+surface is available, the source initializes OpenVR
 as a background client and requests SteamVR's native D3D11 compositor mirror.
 It does not register an OpenVR application layer or change the active OpenXR
-runtime. Select left eye, right eye, or both eyes side by side in source
-properties.
+runtime, and it never launches SteamVR itself. The explicit advanced OpenVR
+source remains available when separate SteamVR-specific eye and crop settings
+are useful.
 
 OBS and SteamVR must use the same GPU. If the source is blank, choose
 **Reconnect to SteamVR** in its properties and inspect the OBS log for an

--- a/docs/release-notes/v0.3.0-beta.13.md
+++ b/docs/release-notes/v0.3.0-beta.13.md
@@ -1,0 +1,43 @@
+# OpenXR OBS Mirror v0.3.0 Beta 13
+
+Beta 13 makes the existing OBS capture source work automatically with both
+OpenXR and OpenVR/SteamVR applications. Existing OBS scenes do not need to be
+rebuilt.
+
+## Automatic runtime capture
+
+- **VR Mirror Capture (Auto: OpenXR / SteamVR)** prefers the OpenXR API-layer
+  surface and transparently falls back to SteamVR's native compositor mirror.
+- The source keeps the original `openxrmirror_capture` ID, so scenes created
+  with **OpenXR Mirror Capture** upgrade in place and no longer remain blank
+  when an application uses OpenVR.
+- The explicit **OpenVR / SteamVR Mirror Capture** source remains available for
+  separate SteamVR-specific eye and crop settings.
+- The fallback only attaches when SteamVR is already running. It cannot launch
+  SteamVR, select a simulator, or change the active OpenXR runtime.
+
+## Clearer Control Center status
+
+- A detected OpenVR application is now reported as capturable through the
+  automatic OBS source instead of incorrectly saying it is unsupported.
+- The OpenXR-only in-app preview clearly directs OpenVR capture to OBS rather
+  than waiting indefinitely for an OpenXR frame.
+- A simulator configured as the system OpenXR runtime is now shown as a warning
+  instead of the incorrect green **Headset runtime selected** state.
+- **Use headset runtime** no longer claims success when the system runtime itself
+  is a simulator; it explains that the headset or SteamVR software must first be
+  selected as the active OpenXR runtime.
+
+## Validation
+
+The automatic source was exercised against a live OpenVR application through
+the saved OpenXR-compatible source ID. The capture produced changing, non-black
+frames while the application loaded `openvr_api.dll` and `vrclient_x64.dll`.
+The explicit OpenVR source was rechecked independently, and both native and
+Control Center release builds complete successfully.
+
+## Install or update
+
+Close OBS Studio, run `OpenXR-OBSMirror-0.3.0-beta.13-Setup.exe`, and reopen
+OBS. Keep the existing source in your scene; it will switch capture backends
+automatically.

--- a/installer/OpenXR-OBSMirror.iss
+++ b/installer/OpenXR-OBSMirror.iss
@@ -1,8 +1,8 @@
 #ifndef MyAppVersion
-  #define MyAppVersion "0.3.0-beta.12"
+  #define MyAppVersion "0.3.0-beta.13"
 #endif
 #ifndef MyFileVersion
-  #define MyFileVersion "0.3.0.12"
+  #define MyFileVersion "0.3.0.13"
 #endif
 #ifndef PayloadRoot
   #define PayloadRoot "..\artifacts\payload"

--- a/scripts/Build-Release.ps1
+++ b/scripts/Build-Release.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
-    [string]$Version = '0.3.0-beta.12',
-    [string]$FileVersion = '0.3.0.12',
+    [string]$Version = '0.3.0-beta.13',
+    [string]$FileVersion = '0.3.0.13',
     [string]$OBSSourcePath = 'E:\Github\obs-studio',
     [string]$OBSInstallPath = 'C:\Program Files\obs-studio'
 )


### PR DESCRIPTION
## What changed

- Keeps the existing `openxrmirror_capture` source ID but automatically falls back to SteamVR's native compositor mirror when no OpenXR layer surface is available.
- Retains the explicit OpenVR source for advanced per-source configuration.
- Refactors native OpenVR capture into a reusable backend and prevents fallback initialization from launching SteamVR.
- Corrects Control Center status for OpenVR applications and for a simulator configured as the system OpenXR runtime.
- Updates installation guidance, source naming, version stamps, and Beta 13 release notes.

## Why

Beta 12 registered OpenVR support as a separate OBS source. Existing scenes still referenced the OpenXR-only source, so OpenVR applications remained blank and Control Center incorrectly said they could not be captured.

## User impact

Existing scenes upgrade in place; users do not have to remove or recreate the source. The source prefers the OpenXR layer when present and uses SteamVR only when needed. The fallback does not launch SteamVR or change the active OpenXR runtime.

## Validation

- Full Release x64 layer, OBS plugin, Control Center, installer, and portable package build completed.
- Existing `openxrmirror_capture` source tested against a live OpenVR application: 2,099 frames, 1,428 changing frames, non-black sampled output.
- Installed packaged Beta 13 into the shared OBS plugin directory and confirmed the installed DLL hash matches the build.
- Opened the unchanged OBS scene and visually confirmed the running OpenVR view appears.
- Rechecked the explicit OpenVR source independently with changing, non-black output.
- Control Center visual check confirmed corrected SteamVR and simulator-runtime states.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the existing VR mirror source auto-switch between OpenXR and SteamVR so current scenes keep working without changes. Keeps the `openxrmirror_capture` ID and updates the source label to “VR Mirror Capture (Auto: OpenXR / SteamVR)”.

- **New Features**
  - `openxrmirror_capture` now prefers the OpenXR layer and falls back to the SteamVR compositor when needed.
  - Fallback only attaches when `vrserver.exe` is already running; it does not launch SteamVR or change the active OpenXR runtime.
  - The explicit `openvrmirror_capture` source remains for advanced per-source eye/crop settings.

- **Bug Fixes**
  - Control Center correctly reports OpenVR apps as capturable via the automatic source and clarifies that the in-app preview is OpenXR-only.
  - Simulator-selected runtimes show a warning state and clearer guidance; “Use headset runtime” no longer reports success when the system runtime is a simulator.

<sup>Written for commit 318ba8ed2d3f651c2340f8fd671f75bdb0e1d811. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elliotttate/OpenXR-Layer-OBSMirror/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

