### PR TITLE
Add live OpenVR preview to Control Center

### DIFF
--- a/ControlCenter/MainWindow.xaml
+++ b/ControlCenter/MainWindow.xaml
@@ -237,9 +237,9 @@
                                             </Grid.ColumnDefinitions>
                                             <StackPanel Spacing="2" VerticalAlignment="Center">
                                                 <TextBlock Text="LIVE MIRROR PREVIEW" Style="{StaticResource EyebrowStyle}" />
-                                                <TextBlock x:Name="PreviewStatusText" Text="Waiting for an OpenXR app" FontSize="18" FontWeight="SemiBold" />
+                                                <TextBlock x:Name="PreviewStatusText" Text="Waiting for a VR app" FontSize="18" FontWeight="SemiBold" />
                                                 <TextBlock x:Name="PreviewDetailText"
-                                                           Text="Start a VR app after enabling the OpenXR layer."
+                                                           Text="Start an OpenXR or OpenVR app; the preview connects automatically."
                                                            Style="{StaticResource MutedTextStyle}" FontSize="11"
                                                            MaxLines="1" TextTrimming="CharacterEllipsis" />
                                             </StackPanel>
@@ -267,7 +267,7 @@
                                                     <TextBlock x:Name="PreviewPlaceholderTitle" Text="No mirror image yet"
                                                                FontSize="17" FontWeight="SemiBold" HorizontalAlignment="Center" />
                                                     <TextBlock x:Name="PreviewPlaceholderDetail"
-                                                               Text="The preview connects automatically when an OpenXR app publishes a frame."
+                                                               Text="The preview connects automatically to OpenXR or OpenVR capture."
                                                                Style="{StaticResource MutedTextStyle}" FontSize="11" TextAlignment="Center" TextWrapping="Wrap" />
                                                 </StackPanel>
                                             </Grid>

--- a/ControlCenter/MainWindow.xaml.cs
+++ b/ControlCenter/MainWindow.xaml.cs
@@ -732,18 +732,6 @@ public sealed partial class MainWindow : Window
 
     private void RenderMirrorPreview(MirrorPreviewResult result)
     {
-        if (result.Frame is null &&
-            _snapshot?.NonOpenXrVrPath.Equals("OpenVR/SteamVR", StringComparison.OrdinalIgnoreCase) == true &&
-            !string.IsNullOrWhiteSpace(_snapshot.NonOpenXrVrApp))
-        {
-            result = new MirrorPreviewResult(
-                null,
-                "SteamVR capture is ready in OBS",
-                "Open OBS to view the running OpenVR/SteamVR application. This in-app preview reads the OpenXR layer only.",
-                false,
-                false);
-        }
-
         _lastPreviewResult = result;
         UpdateVrRestartIndicator();
         PreviewStatusText.Text = result.Status;

--- a/ControlCenter/MirrorPreviewWindow.xaml
+++ b/ControlCenter/MirrorPreviewWindow.xaml
@@ -19,7 +19,7 @@
             <StackPanel Spacing="3">
                 <TextBlock Text="LIVE MIRROR PREVIEW" Foreground="#FF58D7DF"
                            FontSize="12" FontWeight="SemiBold" CharacterSpacing="110" />
-                <TextBlock x:Name="LargePreviewStatusText" Text="Waiting for an OpenXR app"
+                <TextBlock x:Name="LargePreviewStatusText" Text="Waiting for a VR app"
                            FontSize="24" FontWeight="SemiBold" />
                 <TextBlock x:Name="LargePreviewDetailText"
                            Text="The preview will connect automatically when a frame is published."
@@ -37,7 +37,7 @@
                     <TextBlock x:Name="LargePreviewPlaceholderTitle" Text="No mirror image yet"
                                FontSize="20" FontWeight="SemiBold" HorizontalAlignment="Center" />
                     <TextBlock x:Name="LargePreviewPlaceholderDetail"
-                               Text="Start a VR app after enabling the OpenXR layer."
+                               Text="Start an OpenXR or OpenVR app; the preview connects automatically."
                                Foreground="#FFAAB2C3" TextAlignment="Center" TextWrapping="Wrap" />
                 </StackPanel>
             </Grid>

--- a/ControlCenter/OBSMirror.ControlCenter.csproj
+++ b/ControlCenter/OBSMirror.ControlCenter.csproj
@@ -17,13 +17,14 @@
     <RootNamespace>OBSMirror.ControlCenter</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\OBSMirror.ControlCenter.ico</ApplicationIcon>
-    <Version>0.3.0-beta.13</Version>
-    <AssemblyVersion>0.3.0.13</AssemblyVersion>
-    <FileVersion>0.3.0.13</FileVersion>
-    <InformationalVersion>0.3.0-beta.13</InformationalVersion>
+    <Version>0.3.0-beta.14</Version>
+    <AssemblyVersion>0.3.0.14</AssemblyVersion>
+    <FileVersion>0.3.0.14</FileVersion>
+    <InformationalVersion>0.3.0-beta.14</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\external\OpenVR\headers\openvr_api.cs" Link="External\OpenVR\openvr_api.cs" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260508005" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
     <PackageReference Include="Vortice.D3DCompiler" Version="3.6.2" />
@@ -34,6 +35,10 @@
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
     <Content Include="Assets\OBSMirror.ControlCenter.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Include="..\external\OpenVR\bin\win64\openvr_api.dll" Link="openvr_api.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>

--- a/ControlCenter/Services/MirrorPreviewService.cs
+++ b/ControlCenter/Services/MirrorPreviewService.cs
@@ -39,6 +39,7 @@ public sealed record MirrorProducerIdentity(
 /// </summary>
 public sealed class MirrorPreviewService : IDisposable
 {
+    private readonly OpenVrPreviewService _openVrPreview = new();
     private const string SharedMemoryName = "OpenXROBSMirrorSurface";
     // Layout constants mirror shared/obs_mirror_ipc.h; static_asserts there pin
     // every offset used here. The section is page-granular, so mapping a full
@@ -157,6 +158,11 @@ public sealed class MirrorPreviewService : IDisposable
                     "Reopen the app to start the mirror preview again.");
 
             if (!EnsureSurface(out var mappingError))
+            {
+                var openVrResult = _openVrPreview.CaptureFrame();
+                if (OpenVrPreviewService.IsRuntimeRunning())
+                    return openVrResult;
+
                 return DiagnosticWaiting(
                     mappingError.Contains("Start a VR app", StringComparison.OrdinalIgnoreCase)
                         ? "no-shared-surface"
@@ -164,6 +170,7 @@ public sealed class MirrorPreviewService : IDisposable
                     "Waiting for an OpenXR app",
                     mappingError,
                     warning: !mappingError.Contains("Start a VR app", StringComparison.OrdinalIgnoreCase));
+            }
 
             try
             {
@@ -1137,6 +1144,7 @@ public sealed class MirrorPreviewService : IDisposable
                 return;
             _disposed = true;
             ResetSurface();
+            _openVrPreview.Dispose();
         }
     }
 }

--- a/ControlCenter/Services/OpenVrPreviewService.cs
+++ b/ControlCenter/Services/OpenVrPreviewService.cs
@@ -1,0 +1,408 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Valve.VR;
+using Vortice.D3DCompiler;
+using Vortice.Direct3D;
+using Vortice.Direct3D11;
+using Vortice.DXGI;
+using Vortice.Mathematics;
+using static Vortice.Direct3D11.D3D11;
+using static Vortice.DXGI.DXGI;
+
+namespace OBSMirror.ControlCenter.Services;
+
+/// <summary>
+/// Reads SteamVR's native right-eye compositor mirror directly. This is kept
+/// separate from the OpenXR shared-surface reader so merely opening Control
+/// Center can never start SteamVR or change the active OpenXR runtime.
+/// </summary>
+internal sealed class OpenVrPreviewService : IDisposable
+{
+    private const int ReadbackRingDepth = 3;
+    private const int PreviewMaxWidth = 960;
+    private const int PreviewMaxHeight = 540;
+    private const string PreviewShaderSource = """
+        struct VertexOutput
+        {
+            float4 Position : SV_Position;
+            float2 TexCoord : TEXCOORD0;
+        };
+
+        VertexOutput VSMain(uint vertexId : SV_VertexID)
+        {
+            VertexOutput output;
+            float2 texCoord = float2((vertexId << 1) & 2, vertexId & 2);
+            output.Position = float4(texCoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+            output.TexCoord = texCoord;
+            return output;
+        }
+
+        Texture2D MirrorTexture : register(t0);
+        SamplerState MirrorSampler : register(s0);
+
+        float4 PSMain(VertexOutput input) : SV_Target
+        {
+            return float4(MirrorTexture.Sample(MirrorSampler, input.TexCoord).rgb, 1.0);
+        }
+        """;
+
+    private CVRSystem? _system;
+    private CVRCompositor? _compositor;
+    private bool _runtimeAcquired;
+    private IntPtr _openVrMirrorView;
+    private ID3D11Device? _device;
+    private ID3D11DeviceContext? _context;
+    private ID3D11ShaderResourceView? _mirrorView;
+    private ID3D11Texture2D? _mirrorTexture;
+    private ID3D11Texture2D? _downsampleTexture;
+    private ID3D11RenderTargetView? _downsampleTargetView;
+    private ID3D11VertexShader? _vertexShader;
+    private ID3D11PixelShader? _pixelShader;
+    private ID3D11SamplerState? _sampler;
+    private readonly ID3D11Texture2D?[] _readbackRing = new ID3D11Texture2D?[ReadbackRingDepth];
+    private long _readbackIssued;
+    private long _lastInitializeAttempt;
+    private string _lastInitializeError = "SteamVR is not running.";
+    private string _adapterName = "Not selected";
+    private bool _disposed;
+
+    public MirrorPreviewResult CaptureFrame()
+    {
+        if (_disposed)
+            return Waiting("SteamVR preview stopped", "Reopen the app to restart the preview.");
+
+        if (_device is null && !TryInitialize())
+            return Waiting("Waiting for a SteamVR mirror", _lastInitializeError);
+
+        try
+        {
+            RenderPreview();
+            var writeSlot = (int)(_readbackIssued % ReadbackRingDepth);
+            _context!.CopyResource(_readbackRing[writeSlot]!, _downsampleTexture!);
+            _context.Flush();
+            _readbackIssued++;
+            var mapSlot = _readbackIssued >= ReadbackRingDepth
+                ? (int)(_readbackIssued % ReadbackRingDepth)
+                : 0;
+            var readback = _readbackRing[mapSlot]!;
+            var mapped = _context.Map(readback, 0, MapMode.Read, Vortice.Direct3D11.MapFlags.None);
+            MirrorPreviewFrame frame;
+            try
+            {
+                frame = CopyBgraFrame(
+                    mapped,
+                    readback.Description,
+                    _mirrorTexture!.Description.Width,
+                    _mirrorTexture.Description.Height);
+            }
+            finally
+            {
+                _context.Unmap(readback, 0);
+            }
+
+            return new MirrorPreviewResult(
+                frame,
+                "Live SteamVR mirror",
+                $"Right eye  •  Source {_mirrorTexture.Description.Width} × {_mirrorTexture.Description.Height}  •  " +
+                $"Preview {frame.Width} × {frame.Height}  •  {_adapterName}",
+                true,
+                true);
+        }
+        catch (Exception ex)
+        {
+            Reset();
+            _lastInitializeError = $"SteamVR preview paused: {FriendlyError(ex)}";
+            return Waiting("SteamVR preview paused", _lastInitializeError);
+        }
+    }
+
+    private bool TryInitialize()
+    {
+        var now = Environment.TickCount64;
+        if (now - _lastInitializeAttempt < 2000)
+            return false;
+        _lastInitializeAttempt = now;
+        Reset();
+
+        if (!IsRuntimeRunning())
+        {
+            _lastInitializeError = "Start SteamVR and an OpenVR application; the preview will connect automatically.";
+            return false;
+        }
+
+        try
+        {
+            var initError = EVRInitError.None;
+            _system = OpenVR.Init(ref initError, EVRApplicationType.VRApplication_Background);
+            if (initError != EVRInitError.None || _system is null)
+                throw new InvalidOperationException($"OpenVR initialization failed: {OpenVR.GetStringForHmdError(initError)}");
+            _runtimeAcquired = true;
+            _compositor = OpenVR.Compositor
+                          ?? throw new InvalidOperationException("SteamVR did not expose its compositor interface.");
+
+            using var factory = CreateDXGIFactory1<IDXGIFactory1>();
+            var featureLevels = new[]
+            {
+                FeatureLevel.Level_11_1,
+                FeatureLevel.Level_11_0,
+                FeatureLevel.Level_10_1,
+                FeatureLevel.Level_10_0
+            };
+            string? lastAdapterError = null;
+            uint selectedWidth = 0;
+            uint selectedHeight = 0;
+            for (uint adapterIndex = 0; ; adapterIndex++)
+            {
+                if (factory.EnumAdapters1(adapterIndex, out var adapter).Failure)
+                    break;
+                using (adapter)
+                {
+                    ID3D11Device? candidateDevice = null;
+                    ID3D11DeviceContext? candidateContext = null;
+                    IntPtr candidateMirrorView = IntPtr.Zero;
+                    ID3D11ShaderResourceView? candidateWrappedView = null;
+                    ID3D11Texture2D? candidateTexture = null;
+                    try
+                    {
+                        var createResult = D3D11CreateDevice(
+                            adapter,
+                            DriverType.Unknown,
+                            DeviceCreationFlags.BgraSupport,
+                            featureLevels,
+                            out candidateDevice,
+                            out candidateContext);
+                        if (createResult.Failure || candidateDevice is null || candidateContext is null)
+                            throw new InvalidOperationException("Direct3D device creation failed.");
+
+                        var mirrorError = _compositor.GetMirrorTextureD3D11(
+                            EVREye.Eye_Right,
+                            candidateDevice.NativePointer,
+                            ref candidateMirrorView);
+                        if (mirrorError != EVRCompositorError.None || candidateMirrorView == IntPtr.Zero)
+                            throw new InvalidOperationException($"SteamVR compositor error {(int)mirrorError}.");
+
+                        // The Vortice wrapper owns the extra COM reference. The
+                        // original OpenVR view is released separately through
+                        // ReleaseMirrorTextureD3D11, as required by Valve.
+                        Marshal.AddRef(candidateMirrorView);
+                        candidateWrappedView = new ID3D11ShaderResourceView(candidateMirrorView);
+                        using var resource = candidateWrappedView.Resource;
+                        candidateTexture = resource.QueryInterface<ID3D11Texture2D>();
+                        var description = candidateTexture.Description;
+                        if (description.Width == 0 || description.Height == 0)
+                            throw new InvalidOperationException("SteamVR returned an empty mirror texture.");
+
+                        _device = candidateDevice;
+                        candidateDevice = null;
+                        _context = candidateContext;
+                        candidateContext = null;
+                        _openVrMirrorView = candidateMirrorView;
+                        candidateMirrorView = IntPtr.Zero;
+                        _mirrorView = candidateWrappedView;
+                        candidateWrappedView = null;
+                        _mirrorTexture = candidateTexture;
+                        candidateTexture = null;
+                        _adapterName = adapter.Description1.Description.Trim();
+                        selectedWidth = description.Width;
+                        selectedHeight = description.Height;
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        lastAdapterError = $"{adapter.Description1.Description.Trim()}: {FriendlyError(ex)}";
+                        candidateTexture?.Dispose();
+                        candidateWrappedView?.Dispose();
+                        if (candidateMirrorView != IntPtr.Zero)
+                            _compositor.ReleaseMirrorTextureD3D11(candidateMirrorView);
+                        candidateContext?.Dispose();
+                        candidateDevice?.Dispose();
+                    }
+                }
+            }
+
+            if (_device is null)
+                throw new InvalidOperationException(lastAdapterError ?? "No Direct3D adapter exposed the SteamVR mirror.");
+
+            // Resource creation happens after the adapter-selection loop so a
+            // failure is handled by the outer reset path. At this point the
+            // selected device and mirror handle have transferred ownership to
+            // this service and must not be retried as adapter-local objects.
+            CreatePreviewResources(selectedWidth, selectedHeight);
+            _lastInitializeError = string.Empty;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _lastInitializeError = FriendlyError(ex);
+            Reset();
+            return false;
+        }
+    }
+
+    private void CreatePreviewResources(uint sourceWidth, uint sourceHeight)
+    {
+        var (previewWidth, previewHeight) = CalculatePreviewSize(sourceWidth, sourceHeight);
+        var shaderFlags = ShaderFlags.EnableStrictness | ShaderFlags.OptimizationLevel3;
+        var vertexBytecode = Compiler.Compile(
+            PreviewShaderSource, "VSMain", "OpenVrPreview.hlsl", "vs_5_0", shaderFlags, EffectFlags.None);
+        var pixelBytecode = Compiler.Compile(
+            PreviewShaderSource, "PSMain", "OpenVrPreview.hlsl", "ps_5_0", shaderFlags, EffectFlags.None);
+
+        // SteamVR exposes the compositor mirror through an sRGB SRV. Sampling
+        // decodes it to linear light, so the preview render target must be sRGB
+        // as well to encode the pixels again before WinUI displays the BGRA
+        // byte buffer. A linear target makes the preview visibly too dark.
+        var downsampleDescription = new Texture2DDescription(
+            Format.B8G8R8A8_UNorm_SRgb,
+            previewWidth,
+            previewHeight,
+            1,
+            1,
+            BindFlags.RenderTarget,
+            ResourceUsage.Default,
+            CpuAccessFlags.None,
+            1,
+            0,
+            ResourceOptionFlags.None);
+        _downsampleTexture = _device!.CreateTexture2D(in downsampleDescription);
+        _downsampleTargetView = _device.CreateRenderTargetView(_downsampleTexture);
+        _vertexShader = _device.CreateVertexShader(vertexBytecode.Span, null);
+        _pixelShader = _device.CreatePixelShader(pixelBytecode.Span, null);
+        _sampler = _device.CreateSamplerState(new SamplerDescription(
+            Filter.MinMagLinearMipPoint,
+            TextureAddressMode.Clamp,
+            0.0f,
+            1,
+            ComparisonFunction.Never,
+            0.0f,
+            float.MaxValue));
+
+        var readbackDescription = new Texture2DDescription(
+            Format.B8G8R8A8_UNorm_SRgb,
+            previewWidth,
+            previewHeight,
+            1,
+            1,
+            BindFlags.None,
+            ResourceUsage.Staging,
+            CpuAccessFlags.Read,
+            1,
+            0,
+            ResourceOptionFlags.None);
+        for (var index = 0; index < ReadbackRingDepth; index++)
+            _readbackRing[index] = _device.CreateTexture2D(in readbackDescription);
+        _readbackIssued = 0;
+    }
+
+    private void RenderPreview()
+    {
+        var previewDescription = _downsampleTexture!.Description;
+        _context!.OMSetRenderTargets(_downsampleTargetView!, null);
+        _context.RSSetViewports([new Viewport(previewDescription.Width, previewDescription.Height)]);
+        _context.IASetPrimitiveTopology(PrimitiveTopology.TriangleList);
+        _context.VSSetShader(_vertexShader!);
+        _context.PSSetShader(_pixelShader!);
+        _context.PSSetShaderResources(0, [_mirrorView!]);
+        _context.PSSetSamplers(0, [_sampler!]);
+        _context.Draw(3, 0);
+        _context.PSSetShaderResources(0, [null!]);
+        _context.OMSetRenderTargets(Array.Empty<ID3D11RenderTargetView>(), null);
+    }
+
+    private static unsafe MirrorPreviewFrame CopyBgraFrame(
+        MappedSubresource mapped,
+        Texture2DDescription description,
+        uint sourceWidth,
+        uint sourceHeight)
+    {
+        var width = checked((int)description.Width);
+        var height = checked((int)description.Height);
+        var pixels = GC.AllocateUninitializedArray<byte>(checked(width * height * 4));
+        fixed (byte* output = pixels)
+        {
+            for (var y = 0; y < height; y++)
+            {
+                var sourceRow = (uint*)((byte*)mapped.DataPointer + y * mapped.RowPitch);
+                var outputRow = (uint*)(output + y * width * 4);
+                for (var x = 0; x < width; x++)
+                    outputRow[x] = sourceRow[x] | 0xff000000u;
+            }
+        }
+        return new MirrorPreviewFrame(pixels, width, height, sourceWidth, sourceHeight);
+    }
+
+    private static (uint Width, uint Height) CalculatePreviewSize(uint width, uint height)
+    {
+        var scale = Math.Min(
+            1.0,
+            Math.Min(PreviewMaxWidth / (double)width, PreviewMaxHeight / (double)height));
+        return (
+            Math.Max(1u, (uint)Math.Round(width * scale)),
+            Math.Max(1u, (uint)Math.Round(height * scale)));
+    }
+
+    private static MirrorPreviewResult Waiting(string status, string detail) =>
+        new(null, status, detail, false, false);
+
+    internal static bool IsRuntimeRunning()
+    {
+        var processes = Process.GetProcessesByName("vrserver");
+        try
+        {
+            return processes.Length > 0;
+        }
+        finally
+        {
+            foreach (var process in processes)
+                process.Dispose();
+        }
+    }
+
+    private static string FriendlyError(Exception ex) =>
+        string.IsNullOrWhiteSpace(ex.Message) ? ex.GetType().Name : ex.Message;
+
+    private void Reset()
+    {
+        foreach (var readback in _readbackRing)
+            readback?.Dispose();
+        Array.Clear(_readbackRing);
+        _readbackIssued = 0;
+        _sampler?.Dispose();
+        _sampler = null;
+        _pixelShader?.Dispose();
+        _pixelShader = null;
+        _vertexShader?.Dispose();
+        _vertexShader = null;
+        _downsampleTargetView?.Dispose();
+        _downsampleTargetView = null;
+        _downsampleTexture?.Dispose();
+        _downsampleTexture = null;
+        _mirrorTexture?.Dispose();
+        _mirrorTexture = null;
+        _mirrorView?.Dispose();
+        _mirrorView = null;
+        if (_openVrMirrorView != IntPtr.Zero && _compositor is not null)
+            _compositor.ReleaseMirrorTextureD3D11(_openVrMirrorView);
+        _openVrMirrorView = IntPtr.Zero;
+
+        _context?.Dispose();
+        _context = null;
+        _device?.Dispose();
+        _device = null;
+        if (_runtimeAcquired)
+        {
+            OpenVR.Shutdown();
+            _runtimeAcquired = false;
+        }
+        _system = null;
+        _compositor = null;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        Reset();
+    }
+}

--- a/ControlCenter/app.manifest
+++ b/ControlCenter/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="0.3.0.13" name="OBSMirror.ControlCenter.app" />
+  <assemblyIdentity version="0.3.0.14" name="OBSMirror.ControlCenter.app" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/OBSPlugin/win-openxr/win-openxr.cpp
+++ b/OBSPlugin/win-openxr/win-openxr.cpp
@@ -64,7 +64,7 @@ using obs_mirror_ipc::kMirrorTextureCount;
 
 // Logged at load and published through the shared diagnostics block so the
 // layer log records which plugin build it talked to.
-static const char *const kPluginVersion = "0.3.0-beta.13";
+static const char *const kPluginVersion = "0.3.0-beta.14";
 
 struct win_openxrmirror {
 	obs_source_t *source;

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Key recording controls include:
 - recording-only FOV overscan with an unchanged headset center crop;
 - live camera smoothing and crop margin;
 - independent show/hide control for OpenXR composition quad layers;
-- an in-app preview of the layer's shared mirror image;
+- an in-app preview that follows either OpenXR or OpenVR/SteamVR capture;
 - live runtime, layer, plugin, hash, and diagnostic-log status.
 - native SteamVR/OpenVR left-eye, right-eye, or stereo mirror capture.
 
@@ -126,7 +126,7 @@ while the automatic source is using its OpenXR backend.
 
 The dark WinUI 3 Control Center provides one place to inspect layer, plugin,
 runtime, and OBS status; install or update both components; register the layer;
-preview the shared mirror image; configure recording overscan; control camera
+preview the active OpenXR or OpenVR mirror image; configure recording overscan; control camera
 smoothing; show or hide OpenXR quad-layer UI in the recording; and read live logs.
 It is headset-first: the dashboard shows the effective runtime, warns when a
 simulator override is active, and provides **Use headset runtime** to clear
@@ -151,8 +151,10 @@ Run `bin\x64\Release\ControlCenter\OBSMirror.ControlCenter.exe`. Overscan
 changes apply when the OpenXR application next starts. Camera-smoothing changes
 are picked up live by an active OBS Mirror source. Quad-layer visibility is
 picked up live by the updated OpenXR layer after it has been loaded once. The
-Dashboard preview connects directly to the same shared image used by OBS and
-pauses when another Control Center page is selected.
+Dashboard preview connects directly to the active OpenXR shared image or
+SteamVR compositor mirror used by OBS and pauses when another Control Center
+page is selected. Opening Control Center never starts SteamVR or changes the
+active OpenXR runtime.
 
 ## Runtime notes
 

--- a/XR_APILAYER_NOVENDOR_OBSMirror/layer.h
+++ b/XR_APILAYER_NOVENDOR_OBSMirror/layer.h
@@ -27,7 +27,7 @@
 namespace layer_OBSMirror {
 
     const std::string LayerName = "XR_APILAYER_NOVENDOR_OBSMirror";
-    const std::string VersionString = "v0.3.0-beta.13";
+    const std::string VersionString = "v0.3.0-beta.14";
 
     // Singleton accessor.
     OpenXrApi* GetInstance();

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -46,8 +46,9 @@ layer, OBS source, scripts, and app runtime.
   margin update live.
 - **UI layers** can include or omit separately submitted OpenXR quad layers in
   the recording without changing the headset.
-- **Dashboard preview** shows the layer's shared mirror image in the Control
-  Center without requiring OBS to be open.
+- **Dashboard preview** shows the active OpenXR shared image or native SteamVR
+  compositor mirror in Control Center without requiring OBS to be open. It only
+  attaches to SteamVR when SteamVR is already running.
 
 These recording-only controls belong to the OpenXR layer and therefore apply
 only while the automatic source is using OpenXR. Its OpenVR backend receives an already
@@ -100,7 +101,8 @@ registration; both switches always show the same live state.
   This distinguishes an idle producer from advancing all-black frames and from a
   consumer-side display problem. The local log is
   `%LOCALAPPDATA%\OpenXR-OBSMirror\ControlCenter-preview.log`.
-- If no surface or frame is available, start or resume the OpenXR application.
+- If no surface or frame is available, start or resume an OpenXR or OpenVR
+  application.
   If frames and visible pixels are reported but only OBS is black, reopen the OBS
   source properties and compare the OBS and producer adapter identities in the
   uploaded report.

--- a/docs/release-notes/v0.3.0-beta.14.md
+++ b/docs/release-notes/v0.3.0-beta.14.md
@@ -1,0 +1,28 @@
+# OpenXR OBS Mirror v0.3.0-beta.14
+
+Beta 14 brings the automatic OpenXR/OpenVR behavior into Control Center itself.
+The Dashboard and large preview window can now display a running SteamVR mirror
+directly instead of requiring OBS for that view.
+
+## Highlights
+
+- **Live OpenVR preview in Control Center.** The Dashboard and resizable preview
+  window attach directly to SteamVR's compositor mirror when no OpenXR shared
+  surface is active.
+- **Automatic API selection.** OpenXR remains preferred whenever its layer is
+  publishing. Otherwise, an already-running SteamVR session is used without a
+  mode switch or manual source change.
+- **Correct preview brightness.** SteamVR's sRGB mirror is decoded for sampling
+  and encoded back to sRGB before its BGRA pixels are handed to WinUI, avoiding
+  the dark preview produced by a linear intermediate target.
+- **Runtime-safe startup.** Control Center checks for an existing SteamVR server
+  before loading OpenVR, so opening the app cannot launch SteamVR or replace the
+  selected OpenXR runtime.
+- **Safer Direct3D lifetime management.** Mirror views, textures, compositor
+  handles, devices, and adapter retries now have explicit ownership and cleanup.
+
+## Install
+
+Close OBS Studio, run `OpenXR-OBSMirror-0.3.0-beta.14-Setup.exe`, and reopen
+OBS. Existing automatic mirror sources continue to work; no scene change is
+required.

--- a/installer/OpenXR-OBSMirror.iss
+++ b/installer/OpenXR-OBSMirror.iss
@@ -1,8 +1,8 @@
 #ifndef MyAppVersion
-  #define MyAppVersion "0.3.0-beta.13"
+  #define MyAppVersion "0.3.0-beta.14"
 #endif
 #ifndef MyFileVersion
-  #define MyFileVersion "0.3.0.13"
+  #define MyFileVersion "0.3.0.14"
 #endif
 #ifndef PayloadRoot
   #define PayloadRoot "..\artifacts\payload"

--- a/scripts/Build-Release.ps1
+++ b/scripts/Build-Release.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
-    [string]$Version = '0.3.0-beta.13',
-    [string]$FileVersion = '0.3.0.13',
+    [string]$Version = '0.3.0-beta.14',
+    [string]$FileVersion = '0.3.0.14',
     [string]$OBSSourcePath = 'E:\Github\obs-studio',
     [string]$OBSInstallPath = 'C:\Program Files\obs-studio'
 )
@@ -116,10 +116,23 @@ $iscc = 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
 if (-not (Test-Path -LiteralPath $iscc -PathType Leaf)) {
     throw "Inno Setup 6 compiler not found: $iscc"
 }
-& $iscc '/Qp' "/DMyAppVersion=$Version" "/DMyFileVersion=$FileVersion" `
-    "/DPayloadRoot=$payloadRoot" "/DOutputDirectory=$releaseDirectory" `
-    (Join-Path $repoRoot 'installer\OpenXR-OBSMirror.iss')
-if ($LASTEXITCODE -ne 0) { throw "Installer build failed (exit $LASTEXITCODE)." }
+$installerScript = Join-Path $repoRoot 'installer\OpenXR-OBSMirror.iss'
+$isccArguments = @(
+    '/Qp',
+    "/DMyAppVersion=$Version",
+    "/DMyFileVersion=$FileVersion",
+    "/DPayloadRoot=`"$payloadRoot`"",
+    "/DOutputDirectory=`"$releaseDirectory`"",
+    "`"$installerScript`""
+)
+# ISCC is a Windows application, so PowerShell can return from a direct native
+# invocation while the compiler is still writing the installer. Waiting on the
+# process prevents the ZIP/checksum phase from racing a locked partial EXE.
+$isccProcess = Start-Process -FilePath $iscc -ArgumentList $isccArguments `
+    -NoNewWindow -Wait -PassThru
+if ($isccProcess.ExitCode -ne 0) {
+    throw "Installer build failed (exit $($isccProcess.ExitCode))."
+}
 
 $zipPath = Join-Path $releaseDirectory "OpenXR-OBSMirror-$Version-Portable.zip"
 Compress-Archive -LiteralPath $payloadRoot -DestinationPath $zipPath -CompressionLevel Optimal


### PR DESCRIPTION
## Summary
- render an already-running SteamVR compositor mirror directly in Control Center
- preserve OpenXR preference and avoid starting SteamVR or changing the active runtime
- correct SteamVR sRGB preview brightness and harden D3D/OpenVR cleanup
- make release packaging wait for Inno Setup before ZIP/checksum generation
- package as v0.3.0-beta.14 with updated docs

## Validation
- full Release build: OpenXR layer, OBS plugin, Control Center, installer, and portable ZIP
- installed artifact hash matches the commit build
- live Control Center preview verified against an active OpenVR session
- OBS automatic source remained live at matching brightness
- installer completed successfully and packaged OpenVR runtime is present

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live SteamVR/OpenVR mirror preview to Control Center that connects automatically to a running VR app without launching SteamVR or changing the selected OpenXR runtime. Also fixes SteamVR preview brightness, improves stability, and updates release packaging for v0.3.0-beta.14.

- **New Features**
  - Control Center can display the SteamVR compositor mirror (right eye) when no OpenXR shared surface is active.
  - Automatically prefers OpenXR; falls back to OpenVR only when SteamVR is already running. UI text now reflects both APIs.

- **Bug Fixes**
  - Correct sRGB handling for SteamVR mirrors so preview brightness matches OBS.
  - Safer Direct3D/OpenVR resource lifetime and cleanup to prevent leaks and crashes.
  - Release packaging now waits for Inno Setup to complete before ZIP/checksum generation.

<sup>Written for commit c7cc8498a155e21a1a1c43ac11f1ff378c1ae155. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elliotttate/OpenXR-Layer-OBSMirror/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

