### PR TITLE
Recognize static OpenXR clients such as OpenComposite

### DIFF
--- a/ControlCenter.Tests/OBSMirror.ControlCenter.Tests.csproj
+++ b/ControlCenter.Tests/OBSMirror.ControlCenter.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ControlCenter\Services\VrModuleDetector.cs" Link="Services\VrModuleDetector.cs" />
+  </ItemGroup>
+</Project>

--- a/ControlCenter.Tests/VrModuleDetectorTests.cs
+++ b/ControlCenter.Tests/VrModuleDetectorTests.cs
@@ -1,0 +1,76 @@
+using OBSMirror.ControlCenter.Services;
+using Xunit;
+
+namespace OBSMirror.ControlCenter.Tests;
+
+public sealed class VrModuleDetectorTests
+{
+    [Theory]
+    [InlineData("openxr_loader.dll")]
+    [InlineData("XR_APILAYER_NOVENDOR_OBSMirror.dll")]
+    [InlineData("virtualdesktop-openxr.dll")]
+    [InlineData("openxr-oculus-compatibility.dll")]
+    [InlineData("OpenCompositeInput.dll")]
+    [InlineData("OpenComposite.dll")]
+    public void RecognizesOpenXrProofModules(string moduleName)
+    {
+        var result = VrModuleDetector.Analyze([moduleName]);
+
+        Assert.True(result.OpenXrPath);
+        Assert.Empty(result.NonOpenXrPath);
+    }
+
+    [Fact]
+    public void RecognizesOcuUsingItsStaticLoaderThroughVdxr()
+    {
+        var result = VrModuleDetector.Analyze([
+            "SkyrimVR.exe",
+            "openvr_api.dll",
+            "OpenCompositeInput.dll",
+            "virtualdesktop-openxr.dll"
+        ]);
+
+        Assert.True(result.OpenXrPath);
+        Assert.Empty(result.NonOpenXrPath);
+    }
+
+    [Fact]
+    public void OpenXrProofWinsOverASecondaryLibOvrModule()
+    {
+        var result = VrModuleDetector.Analyze([
+            "openvr_api.dll",
+            "OpenCompositeInput.dll",
+            "LibOVRRT64_1.dll"
+        ]);
+
+        Assert.True(result.OpenXrPath);
+        Assert.Empty(result.NonOpenXrPath);
+    }
+
+    [Fact]
+    public void KeepsDirectLibOvrClassifiedAsOculus()
+    {
+        var result = VrModuleDetector.Analyze(["LibOVRRT64_1.dll"]);
+
+        Assert.False(result.OpenXrPath);
+        Assert.Equal("Oculus/LibOVR", result.NonOpenXrPath);
+    }
+
+    [Fact]
+    public void KeepsSteamVrFallbackClassification()
+    {
+        var result = VrModuleDetector.Analyze(["openvr_api.dll", "vrclient_x64.dll"]);
+
+        Assert.False(result.OpenXrPath);
+        Assert.Equal("OpenVR/SteamVR", result.NonOpenXrPath);
+    }
+
+    [Fact]
+    public void DoesNotTreatOpenVrApiAloneAsAnActiveVrPath()
+    {
+        var result = VrModuleDetector.Analyze(["openvr_api.dll"]);
+
+        Assert.False(result.OpenXrPath);
+        Assert.Empty(result.NonOpenXrPath);
+    }
+}

--- a/ControlCenter/Services/OBSMirrorService.cs
+++ b/ControlCenter/Services/OBSMirrorService.cs
@@ -378,13 +378,15 @@ public sealed class OBSMirrorService
     }
 
     /// <summary>
-    /// A running VR application that reaches its runtime without the OpenXR
-    /// loader, or empty strings when there is none.
+    /// A running VR application that reaches its runtime without an observable
+    /// OpenXR path, or empty strings when there is none.
     ///
-    /// API layers are inserted by openxr_loader.dll and by nothing else, so a
-    /// title driving the headset through LibOVR or OpenVR can never load the
-    /// capture layer however it is installed. Reporting the process by name
-    /// turns an endless "waiting for an OpenXR app" into an actionable fact.
+    /// Most applications load openxr_loader.dll dynamically, but OpenComposite
+    /// statically links the Khronos loader into openvr_api.dll. In that case the
+    /// active API layer, runtime, or OpenComposite companion module is the proof
+    /// that the process is using OpenXR. Reporting a genuine LibOVR or OpenVR
+    /// process by name turns an endless "waiting for an OpenXR app" into an
+    /// actionable fact.
     /// Returns nothing while an OpenXR application is running, because then
     /// the loader path is already in use and any second VR process is noise.
     /// </summary>
@@ -414,7 +416,7 @@ public sealed class OBSMirrorService
 
                 scanned++;
                 var usage = ReadVrModuleUsage(process);
-                if (usage.OpenXrLoader)
+                if (usage.OpenXrPath)
                 {
                     openXrApplicationRunning = true;
                     continue;
@@ -453,7 +455,7 @@ public sealed class OBSMirrorService
 
     private static VrModuleUsage ReadVrModuleUsage(Process process)
     {
-        var openXrLoader = false;
+        var openXrPath = false;
         var oculusPath = false;
         var openVrApi = false;
         var openVrClient = false;
@@ -464,13 +466,19 @@ public sealed class OBSMirrorService
                 var name = module.ModuleName;
                 if (string.IsNullOrEmpty(name))
                     continue;
-                if (name.StartsWith("openxr_loader", StringComparison.OrdinalIgnoreCase))
-                    openXrLoader = true;
-                // Virtual Desktop ships its LibOVR and runtime copies under
-                // prefixed names, so these are substring matches on purpose.
-                else if (name.Contains("libovr", StringComparison.OrdinalIgnoreCase) ||
-                         name.Contains("openxr-oculus-compatibility", StringComparison.OrdinalIgnoreCase) ||
-                         name.Contains("virtualdesktop-openxr", StringComparison.OrdinalIgnoreCase))
+                if (name.StartsWith("openxr_loader", StringComparison.OrdinalIgnoreCase) ||
+                    name.StartsWith("XR_APILAYER_", StringComparison.OrdinalIgnoreCase) ||
+                    name.Contains("virtualdesktop-openxr", StringComparison.OrdinalIgnoreCase) ||
+                    name.Contains("openxr-oculus-compatibility", StringComparison.OrdinalIgnoreCase) ||
+                    name.StartsWith("OpenCompositeInput", StringComparison.OrdinalIgnoreCase) ||
+                    name.StartsWith("OpenComposite", StringComparison.OrdinalIgnoreCase))
+                {
+                    // OCU and some other OpenComposite builds embed the OpenXR
+                    // loader, so no openxr_loader.dll appears in the module list.
+                    openXrPath = true;
+                }
+                // A plain LibOVR module still identifies the direct Oculus API.
+                else if (name.Contains("libovr", StringComparison.OrdinalIgnoreCase))
                     oculusPath = true;
                 else if (name.StartsWith("openvr_api", StringComparison.OrdinalIgnoreCase))
                     openVrApi = true;
@@ -483,7 +491,7 @@ public sealed class OBSMirrorService
             // Reading another process's module list is denied for elevated and
             // protected processes; those simply cannot be classified.
         }
-        return new VrModuleUsage(openXrLoader, oculusPath, openVrApi, openVrClient);
+        return new VrModuleUsage(openXrPath, oculusPath, openVrApi, openVrClient);
     }
 
     private static string ClassifyVrPath(VrModuleUsage usage)
@@ -1087,5 +1095,5 @@ public sealed class OBSMirrorService
 
     private sealed record RuntimeSelection(string Path, string Source, bool IsOverride);
 
-    private sealed record VrModuleUsage(bool OpenXrLoader, bool OculusPath, bool OpenVrApi, bool OpenVrClient);
+    private sealed record VrModuleUsage(bool OpenXrPath, bool OculusPath, bool OpenVrApi, bool OpenVrClient);
 }

--- a/ControlCenter/Services/OBSMirrorService.cs
+++ b/ControlCenter/Services/OBSMirrorService.cs
@@ -415,8 +415,8 @@ public sealed class OBSMirrorService
                     continue;
 
                 scanned++;
-                var usage = ReadVrModuleUsage(process);
-                if (usage.OpenXrPath)
+                var detection = ReadVrModuleDetection(process);
+                if (detection.OpenXrPath)
                 {
                     openXrApplicationRunning = true;
                     continue;
@@ -424,7 +424,7 @@ public sealed class OBSMirrorService
                 if (candidateProcess.Length > 0)
                     continue;
 
-                var vrPath = ClassifyVrPath(usage);
+                var vrPath = detection.NonOpenXrPath;
                 if (vrPath.Length == 0)
                     continue;
 
@@ -453,37 +453,16 @@ public sealed class OBSMirrorService
         }
     }
 
-    private static VrModuleUsage ReadVrModuleUsage(Process process)
+    private static VrModuleDetection ReadVrModuleDetection(Process process)
     {
-        var openXrPath = false;
-        var oculusPath = false;
-        var openVrApi = false;
-        var openVrClient = false;
+        var moduleNames = new List<string>();
         try
         {
             foreach (ProcessModule module in process.Modules)
             {
                 var name = module.ModuleName;
-                if (string.IsNullOrEmpty(name))
-                    continue;
-                if (name.StartsWith("openxr_loader", StringComparison.OrdinalIgnoreCase) ||
-                    name.StartsWith("XR_APILAYER_", StringComparison.OrdinalIgnoreCase) ||
-                    name.Contains("virtualdesktop-openxr", StringComparison.OrdinalIgnoreCase) ||
-                    name.Contains("openxr-oculus-compatibility", StringComparison.OrdinalIgnoreCase) ||
-                    name.StartsWith("OpenCompositeInput", StringComparison.OrdinalIgnoreCase) ||
-                    name.StartsWith("OpenComposite", StringComparison.OrdinalIgnoreCase))
-                {
-                    // OCU and some other OpenComposite builds embed the OpenXR
-                    // loader, so no openxr_loader.dll appears in the module list.
-                    openXrPath = true;
-                }
-                // A plain LibOVR module still identifies the direct Oculus API.
-                else if (name.Contains("libovr", StringComparison.OrdinalIgnoreCase))
-                    oculusPath = true;
-                else if (name.StartsWith("openvr_api", StringComparison.OrdinalIgnoreCase))
-                    openVrApi = true;
-                else if (name.StartsWith("vrclient", StringComparison.OrdinalIgnoreCase))
-                    openVrClient = true;
+                if (!string.IsNullOrEmpty(name))
+                    moduleNames.Add(name);
             }
         }
         catch
@@ -491,19 +470,7 @@ public sealed class OBSMirrorService
             // Reading another process's module list is denied for elevated and
             // protected processes; those simply cannot be classified.
         }
-        return new VrModuleUsage(openXrPath, oculusPath, openVrApi, openVrClient);
-    }
-
-    private static string ClassifyVrPath(VrModuleUsage usage)
-    {
-        if (usage.OculusPath)
-            return "Oculus/LibOVR";
-        // openvr_api.dll alone proves nothing: Unreal Engine titles ship it and
-        // load it while running perfectly flat. Only vrclient, which SteamVR
-        // injects once a session actually starts, makes it a VR signal.
-        if (usage.OpenVrApi && usage.OpenVrClient)
-            return "OpenVR/SteamVR";
-        return string.Empty;
+        return VrModuleDetector.Analyze(moduleNames);
     }
 
     /// <summary>
@@ -1095,5 +1062,4 @@ public sealed class OBSMirrorService
 
     private sealed record RuntimeSelection(string Path, string Source, bool IsOverride);
 
-    private sealed record VrModuleUsage(bool OpenXrPath, bool OculusPath, bool OpenVrApi, bool OpenVrClient);
 }

--- a/ControlCenter/Services/VrModuleDetector.cs
+++ b/ControlCenter/Services/VrModuleDetector.cs
@@ -1,0 +1,57 @@
+namespace OBSMirror.ControlCenter.Services;
+
+internal readonly record struct VrModuleDetection(bool OpenXrPath, string NonOpenXrPath);
+
+internal static class VrModuleDetector
+{
+    internal static VrModuleDetection Analyze(IEnumerable<string> moduleNames)
+    {
+        var openXrPath = false;
+        var oculusPath = false;
+        var openVrApi = false;
+        var openVrClient = false;
+
+        foreach (var name in moduleNames)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            if (name.StartsWith("openxr_loader", StringComparison.OrdinalIgnoreCase) ||
+                name.StartsWith("XR_APILAYER_", StringComparison.OrdinalIgnoreCase) ||
+                name.Contains("virtualdesktop-openxr", StringComparison.OrdinalIgnoreCase) ||
+                name.Contains("openxr-oculus-compatibility", StringComparison.OrdinalIgnoreCase) ||
+                name.StartsWith("OpenCompositeInput", StringComparison.OrdinalIgnoreCase) ||
+                name.StartsWith("OpenComposite", StringComparison.OrdinalIgnoreCase))
+            {
+                // OCU and some other OpenComposite builds embed the OpenXR
+                // loader, so no openxr_loader.dll appears in the module list.
+                openXrPath = true;
+            }
+            // A plain LibOVR module still identifies the direct Oculus API.
+            else if (name.Contains("libovr", StringComparison.OrdinalIgnoreCase))
+            {
+                oculusPath = true;
+            }
+            else if (name.StartsWith("openvr_api", StringComparison.OrdinalIgnoreCase))
+            {
+                openVrApi = true;
+            }
+            else if (name.StartsWith("vrclient", StringComparison.OrdinalIgnoreCase))
+            {
+                openVrClient = true;
+            }
+        }
+
+        if (openXrPath)
+            return new VrModuleDetection(true, string.Empty);
+        if (oculusPath)
+            return new VrModuleDetection(false, "Oculus/LibOVR");
+
+        // openvr_api.dll alone proves nothing: Unreal Engine titles ship it and
+        // load it while running perfectly flat. Only vrclient, which SteamVR
+        // injects once a session actually starts, makes it a VR signal.
+        return openVrApi && openVrClient
+            ? new VrModuleDetection(false, "OpenVR/SteamVR")
+            : new VrModuleDetection(false, string.Empty);
+    }
+}

--- a/OpenXR-Layer-OBSMirror.sln
+++ b/OpenXR-Layer-OBSMirror.sln
@@ -7,6 +7,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "XR_APILAYER_NOVENDOR_OBSMir
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OBSMirror.ControlCenter", "ControlCenter\OBSMirror.ControlCenter.csproj", "{C2A6F138-F16B-4A70-8E09-99237E8BCB19}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OBSMirror.ControlCenter.Tests", "ControlCenter.Tests\OBSMirror.ControlCenter.Tests.csproj", "{DFA9A417-80F3-47DD-A8CD-2A795C6F0D3B}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Files", "Solution Files", "{A53ED6CB-95D3-4833-8A16-C6A588F16F6E}"
 	ProjectSection(SolutionItems) = preProject
 		.clang-format = .clang-format
@@ -46,6 +48,14 @@ Global
 		{C2A6F138-F16B-4A70-8E09-99237E8BCB19}.Debug|x64.ActiveCfg = Debug|x64
 		{C2A6F138-F16B-4A70-8E09-99237E8BCB19}.Release|Win32.ActiveCfg = Release|x64
 		{C2A6F138-F16B-4A70-8E09-99237E8BCB19}.Release|x64.ActiveCfg = Release|x64
+		{DFA9A417-80F3-47DD-A8CD-2A795C6F0D3B}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{DFA9A417-80F3-47DD-A8CD-2A795C6F0D3B}.Debug|Win32.Build.0 = Debug|Any CPU
+		{DFA9A417-80F3-47DD-A8CD-2A795C6F0D3B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DFA9A417-80F3-47DD-A8CD-2A795C6F0D3B}.Debug|x64.Build.0 = Debug|Any CPU
+		{DFA9A417-80F3-47DD-A8CD-2A795C6F0D3B}.Release|Win32.ActiveCfg = Release|Any CPU
+		{DFA9A417-80F3-47DD-A8CD-2A795C6F0D3B}.Release|Win32.Build.0 = Release|Any CPU
+		{DFA9A417-80F3-47DD-A8CD-2A795C6F0D3B}.Release|x64.ActiveCfg = Release|Any CPU
+		{DFA9A417-80F3-47DD-A8CD-2A795C6F0D3B}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## What this fixes

The Control Center currently treats a separate openxr_loader.dll as the only proof that a process is using OpenXR. OpenComposite and OCU statically link the Khronos loader into openvr_api.dll, so they can be misidentified as non-OpenXR applications.

Virtual Desktop's virtualdesktop-openxr.dll and openxr-oculus-compatibility layer are also currently classified as Oculus/LibOVR even when they are part of an active OpenXR path.

## Changes

- Recognize loaded OpenXR API layers and known OpenXR runtime modules
- Recognize OpenComposite and OCU companion modules
- Stop classifying VDXR and its OpenXR compatibility layer as direct LibOVR
- Preserve the existing SteamVR/OpenVR fallback classification

## Verification

Built OBSMirror.ControlCenter in Release configuration successfully with zero errors. Existing generated OpenVR nullable warnings remain unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognizes OpenXR paths for static-link clients so Control Center correctly identifies OpenComposite/OCU and Virtual Desktop as OpenXR instead of LibOVR/OpenVR. Previously we required `openxr_loader.dll`; now we detect API layers and known runtime/companion modules, reducing false “non-OpenXR” classifications.

- Extract `VrModuleDetector` and `VrModuleDetection` (`OpenXrPath`, `NonOpenXrPath`) and update `OBSMirrorService` to use it.
- Treat `XR_APILAYER_*`, `virtualdesktop-openxr`, `openxr-oculus-compatibility`, `OpenComposite*`, and `OpenCompositeInput` as OpenXR evidence. Treat plain `libovr` as Oculus. Only classify OpenVR when `openvr_api.dll` and `vrclient*` are both loaded; ignore `openvr_api.dll` alone.
- Add `OBSMirror.ControlCenter.Tests` with `xunit` regression tests covering OpenComposite/OCU via Virtual Desktop, OpenXR-over-LibOVR tie-breakers, and SteamVR fallback; update the solution to include the test project.

<sup>Written for commit 77c77c8664c4b489572435b610751b6079416e74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elliotttate/OpenXR-Layer-OBSMirror/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

