### PR TITLE
Warn about conflicting machine-wide layer registrations

### DIFF
--- a/ControlCenter/MainWindow.xaml
+++ b/ControlCenter/MainWindow.xaml
@@ -213,6 +213,8 @@
                                         </Grid>
                                         <InfoBar x:Name="RuntimeModeInfoBar" IsOpen="True" IsClosable="False" Severity="Informational"
                                                  Title="Checking runtime selection" Message="Reading the effective and system OpenXR runtime settings." />
+                                        <InfoBar x:Name="MachineLayerInfoBar" IsOpen="False" IsClosable="False" Severity="Warning"
+                                                 Title="Machine-wide OBSMirror layer is registered" />
                                         <InfoBar x:Name="ConflictingPluginInfoBar" IsOpen="False" IsClosable="False" Severity="Error"
                                                  Title="An old OBS source copy is taking over">
                                             <InfoBar.ActionButton>

--- a/ControlCenter/MainWindow.xaml.cs
+++ b/ControlCenter/MainWindow.xaml.cs
@@ -287,6 +287,26 @@ public sealed partial class MainWindow : Window
             ? "OBS is running — the update installs when it closes"
             : snapshot.ObsRunning ? "OBS is running" : "OBS is not running";
 
+        var hasMachineLayer = !string.IsNullOrWhiteSpace(snapshot.MachineLayerManifestPaths);
+        MachineLayerInfoBar.IsOpen = hasMachineLayer;
+        if (hasMachineLayer)
+        {
+            MachineLayerInfoBar.Severity = snapshot.MachineLayerCurrent
+                ? InfoBarSeverity.Warning
+                : InfoBarSeverity.Error;
+            MachineLayerInfoBar.Title = snapshot.MachineLayerCurrent
+                ? "Machine-wide OBSMirror layer is registered"
+                : "A different machine-wide OBSMirror layer can take over";
+            MachineLayerInfoBar.Message = snapshot.MachineLayerCurrent
+                ? $"Windows also has OBSMirror registered for every user at {snapshot.MachineLayerManifestPaths}. " +
+                  "Elevated OpenXR applications ignore the per-user registration and use the machine-wide copy. " +
+                  "Run the VR launcher and game without administrator rights so normal updates apply."
+                : $"Windows has a different OBSMirror layer registered for every user at {snapshot.MachineLayerManifestPaths}. " +
+                  "It can override this install. Elevated OpenXR applications ignore the per-user registration, " +
+                  "so they may load that copy or no layer at all. Run the VR launcher and game without administrator rights. " +
+                  "Remove or update only the exact machine-wide entry after confirming it is left over.";
+        }
+
         // A stale copy inside the OBS folder wins source registration over the
         // installed one, so the capture silently runs old code and stays blank.
         var hasConflictingPlugin = !string.IsNullOrWhiteSpace(snapshot.ConflictingPluginPath);

--- a/ControlCenter/Models/SystemSnapshot.cs
+++ b/ControlCenter/Models/SystemSnapshot.cs
@@ -20,6 +20,10 @@ public sealed record SystemSnapshot(
     string SourceLayerHash,
     string PluginHash,
     string SourcePluginHash,
+    // Non-empty when OBSMirror is also registered under HKLM. Elevated OpenXR
+    // applications ignore the current-user layer and may load this copy.
+    string MachineLayerManifestPaths,
+    bool MachineLayerCurrent,
     bool OverscanEnabled,
     int HorizontalPercent,
     int VerticalPercent,

--- a/ControlCenter/Services/OBSMirrorService.cs
+++ b/ControlCenter/Services/OBSMirrorService.cs
@@ -72,6 +72,14 @@ public sealed class OBSMirrorService
         var registeredManifest = FindRegisteredLayerManifest();
         var sourceLayerHash = HashFile(ReleaseLayerPath);
         var layerHash = HashFile(InstalledLayerPath);
+        var machineLayerManifests = FindMachineLayerManifests();
+        var machineLayerCurrent = machineLayerManifests.Count > 0 &&
+                                  !string.IsNullOrEmpty(sourceLayerHash) &&
+                                  machineLayerManifests.All(manifest =>
+                                      string.Equals(
+                                          sourceLayerHash,
+                                          HashFile(ResolveManifestLibraryPath(manifest)),
+                                          StringComparison.OrdinalIgnoreCase));
         var sourcePluginHash = HashFile(ReleasePluginPath);
         var pluginHash = HashFile(PluginPath);
         var sourceOpenVrApiHash = HashFile(ReleaseOpenVrApiPath);
@@ -103,6 +111,8 @@ public sealed class OBSMirrorService
             SourceLayerHash: sourceLayerHash,
             PluginHash: pluginHash,
             SourcePluginHash: sourcePluginHash,
+            MachineLayerManifestPaths: string.Join("; ", machineLayerManifests),
+            MachineLayerCurrent: machineLayerCurrent,
             OverscanEnabled: enabled,
             HorizontalPercent: horizontal,
             VerticalPercent: vertical,
@@ -706,6 +716,39 @@ public sealed class OBSMirrorService
         return key?.GetValueNames().FirstOrDefault(name =>
             Path.GetFileName(name).Equals(LayerManifestName, StringComparison.OrdinalIgnoreCase) &&
             Convert.ToInt32(key.GetValue(name, 1) ?? 1) == 0);
+    }
+
+    private static IReadOnlyList<string> FindMachineLayerManifests()
+    {
+        var manifests = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var view in new[] { RegistryView.Registry64, RegistryView.Registry32 })
+        {
+            try
+            {
+                using var root = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, view);
+                using var key = root.OpenSubKey(LayerRegistryKey);
+                if (key is null)
+                    continue;
+
+                foreach (var valueName in key.GetValueNames())
+                {
+                    if (!Path.GetFileName(valueName).Equals(LayerManifestName, StringComparison.OrdinalIgnoreCase) ||
+                        Convert.ToInt32(key.GetValue(valueName, 1) ?? 1) != 0)
+                    {
+                        continue;
+                    }
+
+                    manifests.Add(Environment.ExpandEnvironmentVariables(valueName.Trim().Trim('"')));
+                }
+            }
+            catch
+            {
+                // A status refresh must still succeed if a registry view is
+                // unavailable or contains a malformed legacy value.
+            }
+        }
+
+        return manifests.OrderBy(path => path, StringComparer.OrdinalIgnoreCase).ToArray();
     }
 
     private static RuntimeSelection ResolveRuntimeSelection()

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -82,6 +82,18 @@ replacing a DLL already loaded by a headset session. Restart the OpenXR
 application to load the new layer. Restart OBS Studio when the OBS source is
 updated.
 
+Setup registers OBSMirror for the current user. If the Control Center reports a
+machine-wide OBSMirror registration, check the manifest path before removing or
+updating it. An old machine-wide copy can take precedence over the current
+per-user version.
+
+Elevated OpenXR applications do not load per-user implicit API layers. Run the
+VR launcher and game without administrator rights when using the normal
+per-user installation. If elevation is required, install both the layer files
+and manifest in an administrator-protected location before registering that
+manifest for all users. Do not register a machine-wide manifest that points to
+a DLL in a user-writable folder.
+
 Use **Installed apps > OpenXR OBS Mirror > Uninstall** to remove the Control
 Center, OBS source, current-user OpenXR layer registration, and installed layer
 files. Close OBS Studio and any OpenXR application first so loaded files can be


### PR DESCRIPTION
## Problem

A stale OBSMirror manifest registered under HKLM can take precedence over the current per-user install. In testing, Skyrim loaded an old v0.2.5 copy from Downloads instead of beta.14 under LocalAppData.

Removing the stale HKLM entry also exposed a second case: an elevated OpenXR application does not load per-user implicit API layers from HKCU, so the layer can disappear completely.

## Root cause

The Windows Khronos OpenXR loader does not read HKCU implicit API layer registrations for a high-integrity process. That behavior protects an elevated process from loading a DLL controlled by a standard user. Registering a LocalAppData DLL under HKLM would bypass that protection and is not a safe installer fix.

## Fix

- Detect enabled OBSMirror manifests under both 64-bit and 32-bit HKLM registry views
- Resolve and hash each registered DLL against the current layer build
- Show an error when a different machine-wide copy can take over
- Show a warning when a matching machine-wide copy exists because per-user updates will not control an elevated application
- Explain that the normal fix is to run the VR launcher and game without administrator rights
- Document that elevated support requires the files and manifest to live in an administrator-protected location

The installer does not delete or rewrite any machine-wide registry value.

## Verification

- Built the Control Center in Release configuration with 0 errors
- Confirmed the revised installer script contains no automatic HKLM cleanup
- Confirmed detection checks both Registry64 and Registry32 and ignores unrelated API layers
- Confirmed no machine-wide registry value was changed during testing